### PR TITLE
Add source code template file with license information

### DIFF
--- a/misc/template.rs
+++ b/misc/template.rs
@@ -1,0 +1,34 @@
+/*
+ * Cairus - a reimplementation of the cairo graphics library in Rust
+ *
+ * Copyright © 20XX CairusOrg
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it either under the terms of the GNU Lesser General Public
+ * License version 2.1 as published by the Free Software Foundation
+ * (the "LGPL") or, at your option, under the terms of the Mozilla
+ * Public License Version 2.0 (the "MPL"). If you do not alter this
+ * notice, a recipient may use your version of this file under either
+ * the MPL or the LGPL.
+ *
+ * You should have received a copy of the LGPL along with this library
+ * in the file LICENSE-LGPL-2_1; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02110-1335, USA
+ * You should have received a copy of the MPL along with this library
+ * in the file LICENSE-MPL-2_0
+ *
+ * The contents of this file are subject to the Mozilla Public License
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY
+ * OF ANY KIND, either express or implied. See the LGPL or the MPL for
+ * the specific language governing rights and limitations.
+ *
+ * The Original Code is the cairus graphics library.
+ *
+ * Contributor(s):
+ *	Name <email@email.org>
+ *
+ */


### PR DESCRIPTION
In addition to a template to be used for new files containing information regarding the right to use the software under MPL 2.0 or LGPL 2.1, this branch adds a `misc` directory for future utilities, texts, etc.