### PR TITLE
Travis CI builds docs and deploys to Github pages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: rust
 rust:
-  - stable
-  - beta
-  - nightly
+- stable
+- beta
+- nightly
 matrix:
   allow_failures:
-    - rust: nightly
+  - rust: nightly
+env:
+  global:
+    secure: Irc56/zFWRPxXA5Eyuij5EV7v8uyij9yRo98bd588EnCjKVGRl/tKN44jVKmp8tuok4cV8FuhSDORLc5vEXvu3VvQPN8OY3L399YQyYL2Vk9yiJYPSk6Lg1gilwdnKiuRXI7gyxQGlw6ZoIaJsuhkQlKFKzuc0MotkjxKpFk8ONL0I1WJqevFCPlryO7hzjUYmXNReXjaE/IRylCYHWRNhIDjTYn+4TzJ6t1ijakmZs4YewyDQv1vuNMeiPZKp2DTe2hjzseZfHPZKYepruHy98mY4u6vDxe3CxNgrGoobZm9of8mTkoAa0RVGXOE0QToORxXejMDHc4EOyMgVHi8FYqhnJ4q+KabVZVstBQb2zwi64U9KVKdEnPu2YS4YxQ+YWMBy5mxWPCNELnV1DTy01NDEU3QIzAIQYHzG4Ir1eTdG5kLW3QRkp2/OOKerymad06ldlj+3DOHkCkACb1hbnwFB54S7gqc5dyhxlb8xnVqDG7tna2Y5QgkrFTHvqtnL+P+H+3RNGkP+tZSIa7WuqY23IfESiwXFO/NnNKAF0f1JRB9HGdb+CZJx9l6LuQ+++VWZv2AHnXpAQiB64xbPWmzM0pmZDm6wiq27PTECZw8f+Rpmnwo23uWtDZbvDyW/PJkFxKMsTbFGrN1O207K+2dIAF0p/NVG8/lMQyXoY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,21 @@ rust:
 matrix:
   allow_failures:
   - rust: nightly
+
 env:
   global:
-    secure: Irc56/zFWRPxXA5Eyuij5EV7v8uyij9yRo98bd588EnCjKVGRl/tKN44jVKmp8tuok4cV8FuhSDORLc5vEXvu3VvQPN8OY3L399YQyYL2Vk9yiJYPSk6Lg1gilwdnKiuRXI7gyxQGlw6ZoIaJsuhkQlKFKzuc0MotkjxKpFk8ONL0I1WJqevFCPlryO7hzjUYmXNReXjaE/IRylCYHWRNhIDjTYn+4TzJ6t1ijakmZs4YewyDQv1vuNMeiPZKp2DTe2hjzseZfHPZKYepruHy98mY4u6vDxe3CxNgrGoobZm9of8mTkoAa0RVGXOE0QToORxXejMDHc4EOyMgVHi8FYqhnJ4q+KabVZVstBQb2zwi64U9KVKdEnPu2YS4YxQ+YWMBy5mxWPCNELnV1DTy01NDEU3QIzAIQYHzG4Ir1eTdG5kLW3QRkp2/OOKerymad06ldlj+3DOHkCkACb1hbnwFB54S7gqc5dyhxlb8xnVqDG7tna2Y5QgkrFTHvqtnL+P+H+3RNGkP+tZSIa7WuqY23IfESiwXFO/NnNKAF0f1JRB9HGdb+CZJx9l6LuQ+++VWZv2AHnXpAQiB64xbPWmzM0pmZDm6wiq27PTECZw8f+Rpmnwo23uWtDZbvDyW/PJkFxKMsTbFGrN1O207K+2dIAF0p/NVG8/lMQyXoY=
+    - secure: Irc56/zFWRPxXA5Eyuij5EV7v8uyij9yRo98bd588EnCjKVGRl/tKN44jVKmp8tuok4cV8FuhSDORLc5vEXvu3VvQPN8OY3L399YQyYL2Vk9yiJYPSk6Lg1gilwdnKiuRXI7gyxQGlw6ZoIaJsuhkQlKFKzuc0MotkjxKpFk8ONL0I1WJqevFCPlryO7hzjUYmXNReXjaE/IRylCYHWRNhIDjTYn+4TzJ6t1ijakmZs4YewyDQv1vuNMeiPZKp2DTe2hjzseZfHPZKYepruHy98mY4u6vDxe3CxNgrGoobZm9of8mTkoAa0RVGXOE0QToORxXejMDHc4EOyMgVHi8FYqhnJ4q+KabVZVstBQb2zwi64U9KVKdEnPu2YS4YxQ+YWMBy5mxWPCNELnV1DTy01NDEU3QIzAIQYHzG4Ir1eTdG5kLW3QRkp2/OOKerymad06ldlj+3DOHkCkACb1hbnwFB54S7gqc5dyhxlb8xnVqDG7tna2Y5QgkrFTHvqtnL+P+H+3RNGkP+tZSIa7WuqY23IfESiwXFO/NnNKAF0f1JRB9HGdb+CZJx9l6LuQ+++VWZv2AHnXpAQiB64xbPWmzM0pmZDm6wiq27PTECZw8f+Rpmnwo23uWtDZbvDyW/PJkFxKMsTbFGrN1O207K+2dIAF0p/NVG8/lMQyXoY=
+    # needed to forbid travis-cargo to pass `--feature nightly` when building with nightly compiler
+    - TRAVIS_CARGO_NIGHTLY_FEATURE=""
+
+before_script:
+  - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
+
+script:
+  - |
+      travis-cargo build &&
+      travis-cargo test &&
+      travis-cargo --only stable doc
+
+after_success:
+  - travis-cargo --only stable doc-upload

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ script:
       travis-cargo --only stable doc
 
 after_success:
-  - travis-cargo --only stable doc-upload --branch test-if-travis-runs-this
+  - travis-cargo --only stable doc-upload --branch develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ script:
       travis-cargo --only stable doc
 
 after_success:
-  - travis-cargo --only stable doc-upload
+  - travis-cargo --only stable doc-upload --branch test-if-travis-runs-this


### PR DESCRIPTION
Just added an encrypted github token and some travis-cargo commands.  The docs will only build for the develop branch.

The pages url will be:
[Cairus Docs](https://cairusorg.github.io/cairus/)
