### PR TITLE
This adds a common geometry utility module.

### DIFF
--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -57,39 +57,39 @@ impl PartialEq for Point {
 /// Defines a line by two points.
 #[derive(Debug, Copy, Clone)]
 pub struct Line {
-    first_endpoint: Point,
-    second_endpoint: Point,
+    point1: Point,
+    point2: Point,
 }
 
 impl Line {
     // Returns a line.  Constructed by (x,y)-coordinates of two points.
     pub fn new(first_x: f32, first_y: f32, second_x: f32, second_y: f32) -> Line {
         Line {
-            first_endpoint: Point{x: first_x, y: first_y},
-            second_endpoint: Point{x: second_x, y: second_y}
+            point1: Point{x: first_x, y: first_y},
+            point2: Point{x: second_x, y: second_y}
         }
     }
 
     // Returns a line.  Constructed from two points.
-    pub fn from_points(first_endpoint: Point, second_endpoint: Point) -> Line {
+    pub fn from_points(point1: Point, point2: Point) -> Line {
         Line {
-            first_endpoint: first_endpoint,
-            second_endpoint: second_endpoint,
+            point1: point1,
+            point2: point2,
         }
     }
 
     pub fn get_slope(&self) -> f32 {
-        let delta_x = self.second_endpoint.x - self.first_endpoint.x;
-        let delta_y = self.second_endpoint.y - self.first_endpoint.y;
+        let delta_x = self.point2.x - self.point1.x;
+        let delta_y = self.point2.y - self.point1.y;
         delta_y / delta_x
     }
 
     // Returns a Point, the midpoint between the two endpoints of self.
     pub fn get_midpoint(&self) -> Point {
-        let mid_x = self.first_endpoint.x + (self.second_endpoint.x - self.first_endpoint.x) / 2.;
+        let mid_x = self.point1.x + (self.point2.x - self.point1.x) / 2.;
         Point {
             x: mid_x,
-            y: self.first_endpoint.y + (mid_x * self.get_slope() ),
+            y: self.point1.y + (mid_x * self.get_slope() ),
         }
     }
 }
@@ -152,8 +152,8 @@ mod tests {
     #[test]
     fn line_new() {
         let line = Line::new(0., 0., 1., 1.);
-        assert_eq!(line.first_endpoint, Point{x: 0., y: 0.});
-        assert_eq!(line.second_endpoint, Point{x: 1., y: 1.});
+        assert_eq!(line.point1, Point{x: 0., y: 0.});
+        assert_eq!(line.point2, Point{x: 1., y: 1.});
     }
 
     #[test]
@@ -161,8 +161,8 @@ mod tests {
         let p1 = Point{x: 0., y: 0.};
         let p2 = Point{x: 1., y: 1.};
         let line = Line::from_points(p1, p2);
-        assert_eq!(line.first_endpoint, Point{x: 0., y: 0.});
-        assert_eq!(line.second_endpoint, Point{x: 1., y: 1.});
+        assert_eq!(line.point1, Point{x: 0., y: 0.});
+        assert_eq!(line.point2, Point{x: 1., y: 1.});
     }
 
     #[test]

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -145,38 +145,6 @@ impl PartialEq for Vector {
     }
 }
 
-/// ## Trapezoid
-///
-/// Defines a trapezoid as four points.
-struct Trapezoid {
-    a: Point,
-    b: Point,
-    c: Point,
-    d: Point,
-}
-
-impl Trapezoid {
-    // Returns a new Trapezoid defined by coordinates.
-    fn new(ax: f32, ay: f32, bx: f32, by: f32, cx: f32, cy: f32, dx: f32, dy: f32) -> Trapezoid {
-        Trapezoid {
-            a: Point {x: ax, y: ay},
-            b: Point {x: bx, y: by},
-            c: Point {x: cx, y: cy},
-            d: Point {x: dx, y: dy},
-        }
-    }
-
-    // Returns a new Trapezoid defined by points.
-    fn from_points(a: Point, b: Point, c: Point, d: Point) -> Trapezoid {
-        Trapezoid {
-            a: a,
-            b: b,
-            c: c,
-            d: d,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::{Line, Point, Vector, Trapezoid};
@@ -243,38 +211,5 @@ mod tests {
         let a = Vector::new(1., 0.);
         let b = Vector::new(1., 1.);
         assert_eq!(a.angle_between(&b).to_degrees(), 45.)
-    }
-
-    #[test]
-    fn trapezoid_new() {
-        let trap = Trapezoid::new(0., 0.,
-                                  0., 1.,
-                                  1., 0.,
-                                  1., 1.);
-
-        let a = Point{x: 0., y: 0.};
-        let b = Point{x: 0., y: 1.};
-        let c = Point{x: 1., y: 0.};
-        let d = Point{x: 1., y: 1.};
-
-        assert_eq!(trap.a, a);
-        assert_eq!(trap.b, b);
-        assert_eq!(trap.c, c);
-        assert_eq!(trap.d, d);
-
-    }
-
-    #[test]
-    fn trapezoid_from_points() {
-        let a = Point{x: 0., y: 0.};
-        let b = Point{x: 0., y: 1.};
-        let c = Point{x: 1., y: 0.};
-        let d = Point{x: 1., y: 1.};
-        let trap = Trapezoid::from_points(a, b, c, d);
-        assert_eq!(trap.a, a);
-        assert_eq!(trap.b, b);
-        assert_eq!(trap.c, c);
-        assert_eq!(trap.d, d);
-
     }
 }

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -42,8 +42,8 @@ use std::ops::Add;
 /// Defines a point by two floating points x and y.
  #[derive(Debug, Copy, Clone)]
 pub struct Point {
-    x: f32,
-    y: f32,
+    pub x: f32,
+    pub y: f32,
 }
 
 impl PartialEq for Point {

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -147,7 +147,7 @@ impl PartialEq for Vector {
 
 #[cfg(test)]
 mod tests {
-    use super::{Line, Point, Vector, Trapezoid};
+    use super::{Line, Point, Vector};
 
     #[test]
     fn line_new() {

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -35,7 +35,7 @@
 
 //! This module defines geometric structs and methods common to algorithms used throughout Cairus.
 
-use std::ops::Add;
+use std::ops::{Add, Sub};
 use std::f32;
 
 /// ## Point
@@ -50,6 +50,14 @@ pub struct Point {
 impl PartialEq for Point {
     fn eq(&self, other: &Point) -> bool {
         self.x == other.x && self.y == other.y
+    }
+}
+
+impl Sub for Point {
+    type Output = Point;
+
+    fn sub(self, other: Point) -> Point {
+        Point{x: self.x - other.x, y: self.y - other.y}
     }
 }
 
@@ -171,6 +179,14 @@ impl PartialEq for Vector {
 #[cfg(test)]
 mod tests {
     use super::{LineSegment, Point, Vector};
+
+    // Tests that point subtraction is working.
+    #[test]
+    fn point_subtraction() {
+        let p1 = Point{x: 0., y: 0.};
+        let p2 = Point{x: 1., y: 1.};
+        assert_eq!(p1 - p2, Point{x: -1., y: -1.});
+    }
 
     // Tests that LineSegment's constructor is working.
     #[test]

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -109,19 +109,10 @@ impl Line {
     }
 
     // Returns a Point, the midpoint between the two endpoints of self.
-    pub fn get_midpoint(&self) -> Point {
-        let slope = self.slope();
-        if self.point1.x == self.point2.x {
-            Point {
-                x: self.point1.x,
-                y: (self.point2.y - self.point1.y) / 2.
-            }
-        } else {
-            let mid_x = self.point1.x + (self.point2.x - self.point1.x) / 2.;
-            Point {
-                x: mid_x,
-                y: self.point1.y + (mid_x * slope),
-            }
+    pub fn midpoint(&self) -> Point {
+        Point {
+            x: (self.point1.x + self.point2.x) / 2.,
+            y: (self.point1.y + self.point2.y) / 2.,
         }
     }
 }
@@ -206,13 +197,31 @@ mod tests {
     #[test]
     fn line_midpoint() {
         let line = Line::new(0., 0., 2., 2.);
-        assert_eq!(line.get_midpoint(), Point{x: 1., y: 1.});
+        assert_eq!(line.midpoint(), Point{x: 1., y: 1.});
+    }
+
+    #[test]
+    fn line_opposite_direction_midpoint() {
+        let line = Line::new(2., 2., 0., 0.);
+        assert_eq!(line.midpoint(), Point{x: 1., y: 1.});
+    }
+
+    #[test]
+    fn line_negative_slope_midpoint() {
+        let line = Line::new(0., 0., 2., -2.);
+        assert_eq!(line.midpoint(), Point{x: 1., y: -1.});
     }
 
     #[test]
     fn vertical_line_midpoint() {
         let line = Line::new(0., 0., 0., 2.);
-        assert_eq!(line.get_midpoint(), Point{x: 0., y: 1.});
+        assert_eq!(line.midpoint(), Point{x: 0., y: 1.});
+    }
+
+    #[test]
+    fn vertical_negative_slope_midpoint() {
+        let line = Line::new(0., 0., 0., -2.);
+        assert_eq!(line.midpoint(), Point{x: 0., y: -1.});
     }
 
     #[test]

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -71,6 +71,14 @@ impl Line {
         let delta_y = self.second_endpoint.y - self.first_endpoint.y;
         delta_y / delta_x
     }
+
+    fn get_midpoint(&self) -> Point {
+        let mid_x = self.first_endpoint.x + (self.second_endpoint.x - self.first_endpoint.x) / 2.;
+        Point {
+            x: mid_x,
+            y: self.first_endpoint.y + (mid_x * self.get_slope() ),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -97,5 +105,11 @@ mod tests {
     fn line_get_slope() {
         let line = Line::new(0., 0., 1., 1.);
         assert_eq!(line.get_slope(), 1.);
+    }
+
+    #[test]
+    fn line_midpoint() {
+        let line = Line::new(0., 0., 2., 2.);
+        assert_eq!(line.get_midpoint(), Point{x: 1., y: 1.});
     }
 }

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -90,22 +90,22 @@ struct Vector {
 }
 
 impl Vector {
-    fn new(x: f32, y: f32) -> Vector {
+    pub fn new(x: f32, y: f32) -> Vector {
         Vector {
             x: x,
             y: y,
         }
     }
 
-    fn dot_product(&self, rhs: &Vector) -> f32 {
+    pub fn dot_product(&self, rhs: &Vector) -> f32 {
         (self.x * rhs.x) + (self.y * rhs.y)
     }
 
-    fn get_magnitude(&self) -> f32 {
+    pub fn get_magnitude(&self) -> f32 {
         (self.x.powi(2) + self.y.powi(2)).sqrt()
     }
 
-    fn angle_between(&self, rhs: &Vector) -> f32 {
+    pub fn angle_between(&self, rhs: &Vector) -> f32 {
         (
             self.dot_product(rhs) / (self.get_magnitude() * rhs.get_magnitude())
         ).acos()

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -98,11 +98,17 @@ impl Vector {
     }
 
     fn dot_product(&self, rhs: &Vector) -> f32 {
-        self.x * rhs.x + self.y * rhs.y
+        (self.x * rhs.x) + (self.y * rhs.y)
     }
 
     fn get_magnitude(&self) -> f32 {
         (self.x.powi(2) + self.y.powi(2)).sqrt()
+    }
+
+    fn angle_between(&self, rhs: &Vector) -> f32 {
+        (
+            self.dot_product(rhs) / (self.get_magnitude() * rhs.get_magnitude())
+        ).acos()
     }
 }
 
@@ -172,15 +178,22 @@ mod tests {
 
     #[test]
     fn vector_dot_product() {
-        let a = Vector::new(0., 0.);
+        let a = Vector::new(1., 0.);
         let b = Vector::new(1., 1.);
         let c = a.dot_product(&b);
-        assert_eq!(c, 0.);
+        assert_eq!(c, 1.);
     }
 
     #[test]
     fn vector_magnitude() {
         let b = Vector::new(3., 4.);
         assert_eq!(b.get_magnitude(), 5.);
+    }
+
+    #[test]
+    fn vector_angle_between() {
+        let a = Vector::new(1., 0.);
+        let b = Vector::new(1., 1.);
+        assert_eq!(a.angle_between(&b).to_degrees(), 45.)
     }
 }

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -34,7 +34,7 @@
  */
 
  #[derive(Debug)]
-struct Point {
+pub struct Point {
     x: f32,
     y: f32,
 }
@@ -46,33 +46,33 @@ impl PartialEq for Point {
 }
 
 #[derive(Debug)]
-struct Line {
+pub struct Line {
     first_endpoint: Point,
     second_endpoint: Point,
 }
 
 impl Line {
-    fn new(first_x: f32, first_y: f32, second_x: f32, second_y: f32) -> Line {
+    pub fn new(first_x: f32, first_y: f32, second_x: f32, second_y: f32) -> Line {
         Line {
             first_endpoint: Point{x: first_x, y: first_y},
             second_endpoint: Point{x: second_x, y: second_y}
         }
     }
 
-    fn from_points(first_endpoint: Point, second_endpoint: Point) -> Line {
+    pub fn from_points(first_endpoint: Point, second_endpoint: Point) -> Line {
         Line {
             first_endpoint: first_endpoint,
             second_endpoint: second_endpoint,
         }
     }
 
-    fn get_slope(&self) -> f32 {
+    pub fn get_slope(&self) -> f32 {
         let delta_x = self.second_endpoint.x - self.first_endpoint.x;
         let delta_y = self.second_endpoint.y - self.first_endpoint.y;
         delta_y / delta_x
     }
 
-    fn get_midpoint(&self) -> Point {
+    pub fn get_midpoint(&self) -> Point {
         let mid_x = self.first_endpoint.x + (self.second_endpoint.x - self.first_endpoint.x) / 2.;
         Point {
             x: mid_x,
@@ -81,9 +81,23 @@ impl Line {
     }
 }
 
+struct Vector {
+    x: f32,
+    y: f32,
+}
+
+impl Vector {
+    fn new(x: f32, y: f32) -> Vector {
+        Vector {
+            x: x,
+            y: y,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{Line, Point};
+    use super::{Line, Point, Vector};
 
     #[test]
     fn line_new() {
@@ -111,5 +125,12 @@ mod tests {
     fn line_midpoint() {
         let line = Line::new(0., 0., 2., 2.);
         assert_eq!(line.get_midpoint(), Point{x: 1., y: 1.});
+    }
+
+    #[test]
+    fn vector_new() {
+        let vec = Vector::new(1., 1.);
+        assert_eq!(vec.x, 1.);
+        assert_eq!(vec.y, 1.);
     }
 }

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -33,8 +33,13 @@
  *
  */
 
+//! This module defines geometric structs and methods common to algorithms used throughout Cairus.
+
 use std::ops::Add;
 
+/// ## Point
+///
+/// Defines a point by two floating points x and y.
  #[derive(Debug, Copy, Clone)]
 pub struct Point {
     x: f32,
@@ -47,6 +52,9 @@ impl PartialEq for Point {
     }
 }
 
+/// ## Line
+///
+/// Defines a line by two points.
 #[derive(Debug, Copy, Clone)]
 pub struct Line {
     first_endpoint: Point,
@@ -54,6 +62,7 @@ pub struct Line {
 }
 
 impl Line {
+    // Returns a line.  Constructed by (x,y)-coordinates of two points.
     pub fn new(first_x: f32, first_y: f32, second_x: f32, second_y: f32) -> Line {
         Line {
             first_endpoint: Point{x: first_x, y: first_y},
@@ -61,6 +70,7 @@ impl Line {
         }
     }
 
+    // Returns a line.  Constructed from two points.
     pub fn from_points(first_endpoint: Point, second_endpoint: Point) -> Line {
         Line {
             first_endpoint: first_endpoint,
@@ -74,6 +84,7 @@ impl Line {
         delta_y / delta_x
     }
 
+    // Returns a Point, the midpoint between the two endpoints of self.
     pub fn get_midpoint(&self) -> Point {
         let mid_x = self.first_endpoint.x + (self.second_endpoint.x - self.first_endpoint.x) / 2.;
         Point {
@@ -83,6 +94,9 @@ impl Line {
     }
 }
 
+/// ## Vector
+///
+/// Defines a vector by (x, y) direction.
 #[derive(Debug, Copy, Clone)]
 struct Vector {
     x: f32,
@@ -97,6 +111,7 @@ impl Vector {
         }
     }
 
+    // Returns the dot product of self and rhs.
     pub fn dot_product(&self, rhs: &Vector) -> f32 {
         (self.x * rhs.x) + (self.y * rhs.y)
     }
@@ -105,6 +120,7 @@ impl Vector {
         (self.x.powi(2) + self.y.powi(2)).sqrt()
     }
 
+    // Returns the angle between self and rhs.
     pub fn angle_between(&self, rhs: &Vector) -> f32 {
         (
             self.dot_product(rhs) / (self.get_magnitude() * rhs.get_magnitude())
@@ -129,9 +145,41 @@ impl PartialEq for Vector {
     }
 }
 
+/// ## Trapezoid
+///
+/// Defines a trapezoid as four points.
+struct Trapezoid {
+    a: Point,
+    b: Point,
+    c: Point,
+    d: Point,
+}
+
+impl Trapezoid {
+    // Returns a new Trapezoid defined by coordinates.
+    fn new(ax: f32, ay: f32, bx: f32, by: f32, cx: f32, cy: f32, dx: f32, dy: f32) -> Trapezoid {
+        Trapezoid {
+            a: Point {x: ax, y: ay},
+            b: Point {x: bx, y: by},
+            c: Point {x: cx, y: cy},
+            d: Point {x: dx, y: dy},
+        }
+    }
+
+    // Returns a new Trapezoid defined by points.
+    fn from_points(a: Point, b: Point, c: Point, d: Point) -> Trapezoid {
+        Trapezoid {
+            a: a,
+            b: b,
+            c: c,
+            d: d,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{Line, Point, Vector};
+    use super::{Line, Point, Vector, Trapezoid};
 
     #[test]
     fn line_new() {
@@ -195,5 +243,38 @@ mod tests {
         let a = Vector::new(1., 0.);
         let b = Vector::new(1., 1.);
         assert_eq!(a.angle_between(&b).to_degrees(), 45.)
+    }
+
+    #[test]
+    fn trapezoid_new() {
+        let trap = Trapezoid::new(0., 0.,
+                                  0., 1.,
+                                  1., 0.,
+                                  1., 1.);
+
+        let a = Point{x: 0., y: 0.};
+        let b = Point{x: 0., y: 1.};
+        let c = Point{x: 1., y: 0.};
+        let d = Point{x: 1., y: 1.};
+
+        assert_eq!(trap.a, a);
+        assert_eq!(trap.b, b);
+        assert_eq!(trap.c, c);
+        assert_eq!(trap.d, d);
+
+    }
+
+    #[test]
+    fn trapezoid_from_points() {
+        let a = Point{x: 0., y: 0.};
+        let b = Point{x: 0., y: 1.};
+        let c = Point{x: 1., y: 0.};
+        let d = Point{x: 1., y: 1.};
+        let trap = Trapezoid::from_points(a, b, c, d);
+        assert_eq!(trap.a, a);
+        assert_eq!(trap.b, b);
+        assert_eq!(trap.c, c);
+        assert_eq!(trap.d, d);
+
     }
 }

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -100,6 +100,10 @@ impl Vector {
     fn dot_product(&self, rhs: &Vector) -> f32 {
         self.x * rhs.x + self.y * rhs.y
     }
+
+    fn get_magnitude(&self) -> f32 {
+        (self.x.powi(2) + self.y.powi(2)).sqrt()
+    }
 }
 
 impl Add for Vector {
@@ -172,5 +176,11 @@ mod tests {
         let b = Vector::new(1., 1.);
         let c = a.dot_product(&b);
         assert_eq!(c, 0.);
+    }
+
+    #[test]
+    fn vector_magnitude() {
+        let b = Vector::new(3., 4.);
+        assert_eq!(b.get_magnitude(), 5.);
     }
 }

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -33,7 +33,9 @@
  *
  */
 
- #[derive(Debug)]
+use std::ops::Add;
+
+ #[derive(Debug, Copy, Clone)]
 pub struct Point {
     x: f32,
     y: f32,
@@ -45,7 +47,7 @@ impl PartialEq for Point {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct Line {
     first_endpoint: Point,
     second_endpoint: Point,
@@ -81,6 +83,7 @@ impl Line {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
 struct Vector {
     x: f32,
     y: f32,
@@ -92,6 +95,27 @@ impl Vector {
             x: x,
             y: y,
         }
+    }
+
+    fn dot_product(&self, rhs: &Vector) -> f32 {
+        self.x * rhs.x + self.y * rhs.y
+    }
+}
+
+impl Add for Vector {
+    type Output = Vector;
+
+    fn add(self, other: Vector) -> Vector {
+        Vector {
+            x: self.x + other.x,
+            y: self.y + other.y,
+        }
+    }
+}
+
+impl PartialEq for Vector {
+    fn eq(&self, other: &Vector) -> bool {
+        self.x == other.x && self.y == other.y
     }
 }
 
@@ -132,5 +156,21 @@ mod tests {
         let vec = Vector::new(1., 1.);
         assert_eq!(vec.x, 1.);
         assert_eq!(vec.y, 1.);
+    }
+
+    #[test]
+    fn vector_add() {
+        let a = Vector::new(0., 0.);
+        let b = Vector::new(1., 1.);
+        let c = a + b;
+        assert_eq!(c, b);
+    }
+
+    #[test]
+    fn vector_dot_product() {
+        let a = Vector::new(0., 0.);
+        let b = Vector::new(1., 1.);
+        let c = a.dot_product(&b);
+        assert_eq!(c, 0.);
     }
 }

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -139,14 +139,14 @@ impl Vector {
         (self.x * rhs.x) + (self.y * rhs.y)
     }
 
-    pub fn get_magnitude(&self) -> f32 {
+    pub fn magnitude(&self) -> f32 {
         (self.x.powi(2) + self.y.powi(2)).sqrt()
     }
 
     // Returns the angle between self and rhs.
     pub fn angle_between(&self, rhs: &Vector) -> f32 {
         (
-            self.dot_product(rhs) / (self.get_magnitude() * rhs.get_magnitude())
+            self.dot_product(rhs) / (self.magnitude() * rhs.magnitude())
         ).acos()
     }
 }
@@ -286,7 +286,7 @@ mod tests {
     #[test]
     fn vector_magnitude() {
         let b = Vector::new(3., 4.);
-        assert_eq!(b.get_magnitude(), 5.);
+        assert_eq!(b.magnitude(), 5.);
     }
 
     // Tests Vector::angle_between()

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -53,36 +53,36 @@ impl PartialEq for Point {
     }
 }
 
-/// ## Line
+/// ## LineSegment
 ///
 /// Defines a line by two points.
 #[derive(Debug, Copy, Clone)]
-pub struct Line {
+pub struct LineSegment {
     point1: Point,
     point2: Point,
 }
 
-impl Line {
+impl LineSegment {
     // Returns a line.  Constructed by (x,y)-coordinates of two points.
-    pub fn new(first_x: f32, first_y: f32, second_x: f32, second_y: f32) -> Line {
-        Line {
+    pub fn new(first_x: f32, first_y: f32, second_x: f32, second_y: f32) -> LineSegment {
+        LineSegment {
             point1: Point{x: first_x, y: first_y},
             point2: Point{x: second_x, y: second_y}
         }
     }
 
     // Returns a line.  Constructed from two points.
-    pub fn from_points(point1: Point, point2: Point) -> Line {
-        Line {
+    pub fn from_points(point1: Point, point2: Point) -> LineSegment {
+        LineSegment {
             point1: point1,
             point2: point2,
         }
     }
 
-    /// Returns the slope of this Line.
+    /// Returns the slope of this LineSegment.
     ///
     /// If the slope is completely vertical, this function will return f32::INFINITY, otherwise
-    /// it will return any valid f32 (assuming valid points form this Line).
+    /// it will return any valid f32 (assuming valid points form this LineSegment).
     ///
     /// One of the ways Cairo C implements slope comparision is using the following formula:
     ///     `(adx * bdy) ? (bdx * ady)`, where `?` is the comparison operator.
@@ -170,11 +170,11 @@ impl PartialEq for Vector {
 
 #[cfg(test)]
 mod tests {
-    use super::{Line, Point, Vector};
+    use super::{LineSegment, Point, Vector};
 
     #[test]
     fn line_new() {
-        let line = Line::new(0., 0., 1., 1.);
+        let line = LineSegment::new(0., 0., 1., 1.);
         assert_eq!(line.point1, Point{x: 0., y: 0.});
         assert_eq!(line.point2, Point{x: 1., y: 1.});
     }
@@ -183,65 +183,65 @@ mod tests {
     fn line_from_points() {
         let p1 = Point{x: 0., y: 0.};
         let p2 = Point{x: 1., y: 1.};
-        let line = Line::from_points(p1, p2);
+        let line = LineSegment::from_points(p1, p2);
         assert_eq!(line.point1, Point{x: 0., y: 0.});
         assert_eq!(line.point2, Point{x: 1., y: 1.});
     }
 
     #[test]
     fn line_slope() {
-        let line = Line::new(0., 0., 1., 1.);
+        let line = LineSegment::new(0., 0., 1., 1.);
         assert_eq!(line.slope(), 1.);
     }
 
     #[test]
     fn line_midpoint() {
-        let line = Line::new(0., 0., 2., 2.);
+        let line = LineSegment::new(0., 0., 2., 2.);
         assert_eq!(line.midpoint(), Point{x: 1., y: 1.});
     }
 
     #[test]
     fn line_opposite_direction_midpoint() {
-        let line = Line::new(2., 2., 0., 0.);
+        let line = LineSegment::new(2., 2., 0., 0.);
         assert_eq!(line.midpoint(), Point{x: 1., y: 1.});
     }
 
     #[test]
     fn line_negative_slope_midpoint() {
-        let line = Line::new(0., 0., 2., -2.);
+        let line = LineSegment::new(0., 0., 2., -2.);
         assert_eq!(line.midpoint(), Point{x: 1., y: -1.});
     }
 
     #[test]
     fn vertical_line_midpoint() {
-        let line = Line::new(0., 0., 0., 2.);
+        let line = LineSegment::new(0., 0., 0., 2.);
         assert_eq!(line.midpoint(), Point{x: 0., y: 1.});
     }
 
     #[test]
     fn vertical_negative_slope_midpoint() {
-        let line = Line::new(0., 0., 0., -2.);
+        let line = LineSegment::new(0., 0., 0., -2.);
         assert_eq!(line.midpoint(), Point{x: 0., y: -1.});
     }
 
     #[test]
     fn vertical_slope_gt_positive() {
-        let vertical = Line::new(0., 0., 0., 1.);
-        let positive = Line::new(0., 0., 1., 1.);
+        let vertical = LineSegment::new(0., 0., 0., 1.);
+        let positive = LineSegment::new(0., 0., 1., 1.);
         assert!(vertical.slope() > positive.slope());
     }
 
     #[test]
     fn vertical_slope_gt_negative() {
-        let vertical = Line::new(0., 0., 0., 1.);
-        let negative = Line::new(0., 0., 1., -1.);
+        let vertical = LineSegment::new(0., 0., 0., 1.);
+        let negative = LineSegment::new(0., 0., 1., -1.);
         assert!(vertical.slope() > negative.slope());
     }
 
     #[test]
     fn vertical_slope_eq_vertical() {
-        let vertical1 = Line::new(0., 0., 0., 1.);
-        let vertical2 = Line::new(2., 2., 2., -1.);
+        let vertical1 = LineSegment::new(0., 0., 0., 1.);
+        let vertical2 = LineSegment::new(2., 2., 2., -1.);
         assert_eq!(vertical1.slope(), vertical2.slope());
     }
 

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -65,6 +65,12 @@ impl Line {
             second_endpoint: second_endpoint,
         }
     }
+
+    fn get_slope(&self) -> f32 {
+        let delta_x = self.second_endpoint.x - self.first_endpoint.x;
+        let delta_y = self.second_endpoint.y - self.first_endpoint.y;
+        delta_y / delta_x
+    }
 }
 
 #[cfg(test)]
@@ -87,4 +93,9 @@ mod tests {
         assert_eq!(line.second_endpoint, Point{x: 1., y: 1.});
     }
 
+    #[test]
+    fn line_get_slope() {
+        let line = Line::new(0., 0., 1., 1.);
+        assert_eq!(line.get_slope(), 1.);
+    }
 }

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -172,6 +172,7 @@ impl PartialEq for Vector {
 mod tests {
     use super::{LineSegment, Point, Vector};
 
+    // Tests that LineSegment's constructor is working.
     #[test]
     fn line_new() {
         let line = LineSegment::new(0., 0., 1., 1.);
@@ -179,6 +180,7 @@ mod tests {
         assert_eq!(line.point2, Point{x: 1., y: 1.});
     }
 
+    // Tests that LineSegment's `from_points` alternative constructor is working
     #[test]
     fn line_from_points() {
         let p1 = Point{x: 0., y: 0.};
@@ -188,42 +190,49 @@ mod tests {
         assert_eq!(line.point2, Point{x: 1., y: 1.});
     }
 
+    // Tests that the simple case for LineSegment::slope() is working.
     #[test]
     fn line_slope() {
         let line = LineSegment::new(0., 0., 1., 1.);
         assert_eq!(line.slope(), 1.);
     }
 
+    // Tests that the simple case for LineSegment::midpoint() is working.
     #[test]
     fn line_midpoint() {
         let line = LineSegment::new(0., 0., 2., 2.);
         assert_eq!(line.midpoint(), Point{x: 1., y: 1.});
     }
 
+    // Tests that LineSegment::midpoint() is working when point2's x-value is less than point1's.
     #[test]
     fn line_opposite_direction_midpoint() {
         let line = LineSegment::new(2., 2., 0., 0.);
         assert_eq!(line.midpoint(), Point{x: 1., y: 1.});
     }
 
+    // Tests that midpoint works for lines with negative slope
     #[test]
     fn line_negative_slope_midpoint() {
         let line = LineSegment::new(0., 0., 2., -2.);
         assert_eq!(line.midpoint(), Point{x: 1., y: -1.});
     }
 
+    // Tests that midpoint works for vertical lines
     #[test]
     fn vertical_line_midpoint() {
         let line = LineSegment::new(0., 0., 0., 2.);
         assert_eq!(line.midpoint(), Point{x: 0., y: 1.});
     }
 
+    // Tests that midpoint works for negative vertical lines
     #[test]
     fn vertical_negative_slope_midpoint() {
         let line = LineSegment::new(0., 0., 0., -2.);
         assert_eq!(line.midpoint(), Point{x: 0., y: -1.});
     }
 
+    // Tests greater than slope comparison
     #[test]
     fn vertical_slope_gt_positive() {
         let vertical = LineSegment::new(0., 0., 0., 1.);
@@ -231,6 +240,7 @@ mod tests {
         assert!(vertical.slope() > positive.slope());
     }
 
+    // Tests greater than slope comparison with one negative slope
     #[test]
     fn vertical_slope_gt_negative() {
         let vertical = LineSegment::new(0., 0., 0., 1.);
@@ -238,6 +248,7 @@ mod tests {
         assert!(vertical.slope() > negative.slope());
     }
 
+    // Tests equality of slopes
     #[test]
     fn vertical_slope_eq_vertical() {
         let vertical1 = LineSegment::new(0., 0., 0., 1.);
@@ -245,6 +256,7 @@ mod tests {
         assert_eq!(vertical1.slope(), vertical2.slope());
     }
 
+    // Tests Vector::new()
     #[test]
     fn vector_new() {
         let vec = Vector::new(1., 1.);
@@ -252,6 +264,7 @@ mod tests {
         assert_eq!(vec.y, 1.);
     }
 
+    // Tests overloaded Vector addition operator
     #[test]
     fn vector_add() {
         let a = Vector::new(0., 0.);
@@ -260,6 +273,7 @@ mod tests {
         assert_eq!(c, b);
     }
 
+    // Tests Vector::dot_product()
     #[test]
     fn vector_dot_product() {
         let a = Vector::new(1., 0.);
@@ -268,12 +282,14 @@ mod tests {
         assert_eq!(c, 1.);
     }
 
+    // Tests Vector::magnitude()
     #[test]
     fn vector_magnitude() {
         let b = Vector::new(3., 4.);
         assert_eq!(b.get_magnitude(), 5.);
     }
 
+    // Tests Vector::angle_between()
     #[test]
     fn vector_angle_between() {
         let a = Vector::new(1., 0.);

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -58,8 +58,8 @@ impl PartialEq for Point {
 /// Defines a line by two points.
 #[derive(Debug, Copy, Clone)]
 pub struct LineSegment {
-    point1: Point,
-    point2: Point,
+    pub point1: Point,
+    pub point2: Point,
 }
 
 impl LineSegment {

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -1,0 +1,90 @@
+/*
+ * Cairus - a reimplementation of the cairo graphics library in Rust
+ *
+ * Copyright © 2017 CairusOrg
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it either under the terms of the GNU Lesser General Public
+ * License version 2.1 as published by the Free Software Foundation
+ * (the "LGPL") or, at your option, under the terms of the Mozilla
+ * Public License Version 2.0 (the "MPL"). If you do not alter this
+ * notice, a recipient may use your version of this file under either
+ * the MPL or the LGPL.
+ *
+ * You should have received a copy of the LGPL along with this library
+ * in the file LICENSE-LGPL-2_1; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02110-1335, USA
+ * You should have received a copy of the MPL along with this library
+ * in the file LICENSE-MPL-2_0
+ *
+ * The contents of this file are subject to the Mozilla Public License
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY
+ * OF ANY KIND, either express or implied. See the LGPL or the MPL for
+ * the specific language governing rights and limitations.
+ *
+ * The Original Code is the cairus graphics library.
+ *
+ * Contributor(s):
+ *	Bobby Eshleman <bobbyeshleman@gmail.com>
+ *
+ */
+
+ #[derive(Debug)]
+struct Point {
+    x: f32,
+    y: f32,
+}
+
+impl PartialEq for Point {
+    fn eq(&self, other: &Point) -> bool {
+        self.x == other.x && self.y == other.y
+    }
+}
+
+#[derive(Debug)]
+struct Line {
+    first_endpoint: Point,
+    second_endpoint: Point,
+}
+
+impl Line {
+    fn new(first_x: f32, first_y: f32, second_x: f32, second_y: f32) -> Line {
+        Line {
+            first_endpoint: Point{x: first_x, y: first_y},
+            second_endpoint: Point{x: second_x, y: second_y}
+        }
+    }
+
+    fn from_points(first_endpoint: Point, second_endpoint: Point) -> Line {
+        Line {
+            first_endpoint: first_endpoint,
+            second_endpoint: second_endpoint,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Line, Point};
+
+    #[test]
+    fn line_new() {
+        let line = Line::new(0., 0., 1., 1.);
+        assert_eq!(line.first_endpoint, Point{x: 0., y: 0.});
+        assert_eq!(line.second_endpoint, Point{x: 1., y: 1.});
+    }
+
+    #[test]
+    fn line_from_points() {
+        let p1 = Point{x: 0., y: 0.};
+        let p2 = Point{x: 1., y: 1.};
+        let line = Line::from_points(p1, p2);
+        assert_eq!(line.first_endpoint, Point{x: 0., y: 0.});
+        assert_eq!(line.second_endpoint, Point{x: 1., y: 1.});
+    }
+
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,10 @@ mod types;
 #[allow(dead_code)]
 mod surfaces;
 
+#[allow(dead_code)]
+mod common_geometry;
+
+
 #[cfg(test)]
 mod tests {
     #[test]


### PR DESCRIPTION
## Overview

This module implements the geometry structures and methods layed out in the dot aych file.

Two points of deviation from the original document include:

1. Points are defined with float (x, y) values instead of i32, as some of the algorithms will need greater precision than integers offer.  Although Cairo used the cairo_fixed_t type, which is an integer, you can see the discussion [here](http://pixman.freedesktop.narkive.com/YV6HUW6g/cairo-floating-point-api-in-pixman) on their consideration for converting to all `double` values instead of the fixed type.  The main reason they don't use `double` is because old ARM processors don't have a floating point processing unit, and so operations on floats are slower on these machines than integers.  So instead these `cairo_fixed_t` types are tossed to Pixman as fixed point precision numbers, where the first section of bits internal to that int refer to the integer value, and the remaining bits refer to the fractional part (for more precision).  Since we aren't using Pixman and probably won't see Cairus compiled onto ARM, and would probably need to hand tune for ARM anyway, I thought that doing this bitwise processing for points would be overkill for our immediate purposes.
2. I did not implement a `Trapezoids` struct, as I didn't know what operations it would need yet that a `Vec<Trapezoid>` wouldn't accommodate already.  Of course, I'm sure they exist.  I assumed it would be more efficient for those operations to be added as they are needed. 


## Future

I think that we should add to common_geometry.rs as we need more functionality of out of these structs than I provide here.

## Reference

The contents of the dot ayche file:


Point
- 2 signed i32 types

Line
- Midpoint?
- slope?
 
- Knot
- 4 points
 
Vector
- Add
- angle
 
Trapezoid 
- 4 points

Trapezoids