### PR TITLE
This allows Cairus to take trapezoids and create a mask of out them.

### DIFF
--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -109,7 +109,7 @@ impl Line {
         let slope = self.get_slope();
         match slope <= 1. {
             true => self.step_by_x_coordinates(),
-            false => self.step_by_y_coordinates()
+            false => self.step_by_y_coordinates(),
         }
     }
 
@@ -128,7 +128,17 @@ impl Line {
     }
 
     fn step_by_y_coordinates(&self) -> Vec<(i32, i32)> {
-        vec![(0, 0)]
+        let max_y = self.point1.y.max(self.point2.y) as i32;
+        let slope = 1. / self.get_slope();
+        let mut running_total_x = 0.;
+        let mut result = Vec::with_capacity(max_y as usize);
+        for y in 0..max_y {
+            running_total_x += slope;
+            let coordinate = (running_total_x.round() as i32, y);
+            result.push(coordinate);
+        }
+
+        result
     }
 }
 
@@ -251,6 +261,25 @@ mod tests {
         }
     }
 
+    #[test]
+    fn line_into_pixel_coordinates_slope_gt_one() {
+        // The following coordinates were calculated by hand to be known pixels in the defined
+        // line.
+        let line = Line::new(0., 0., 5., 20.);
+        let expected = vec![
+            (0, 0),
+            (1, 1),
+            (1, 2),
+            (1, 3),
+            (1, 4),
+            (2, 5),
+        ];
+
+        let pixel_coordinates = line.into_pixel_coordinates();
+        for coordinate in expected {
+            assert!(pixel_coordinates.contains(&coordinate));
+        }
+    }
 
     #[test]
     fn vector_new() {

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -123,6 +123,38 @@ impl LineSegment {
             y: (self.point1.y + self.point2.y) / 2.,
         }
     }
+
+    pub fn highest_point(&self) -> Point {
+        if self.point1.y > self.point2.y {
+            self.point1
+        } else {
+            self.point2
+        }
+    }
+
+    pub fn lowest_point(&self) -> Point {
+        if self.point1.y < self.point2.y {
+            self.point1
+        } else {
+            self.point2
+        }
+    }
+
+    pub fn leftmost_point(&self) -> Point {
+        if self.point1.x < self.point2.x {
+            self.point1
+        } else {
+            self.point2
+        }
+    }
+
+    pub fn rightmost_point(&self) -> Point {
+        if self.point1.x > self.point2.x {
+            self.point1
+        } else {
+            self.point2
+        }
+    }
 }
 
 impl PartialEq for LineSegment {
@@ -212,6 +244,18 @@ mod tests {
         let line = LineSegment::from_points(p1, p2);
         assert_eq!(line.point1, Point{x: 0., y: 0.});
         assert_eq!(line.point2, Point{x: 1., y: 1.});
+    }
+
+    // Tests that LineSegment's  highest/lowest/leftmost/rightmost point functions work
+    #[test]
+    fn line_query_functions() {
+        let p1 = Point{x: 0., y: 0.};
+        let p2 = Point{x: 1., y: 1.};
+        let line = LineSegment::from_points(p1, p2);
+        assert_eq!(line.leftmost_point(), p1);
+        assert_eq!(line.lowest_point(), p1);
+        assert_eq!(line.rightmost_point(), p2);
+        assert_eq!(line.highest_point(), p2);
     }
 
     // Tests that LineSegment Eq implementation is working

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -87,6 +87,11 @@ impl LineSegment {
         }
     }
 
+    // Returns the length of this LineSegment
+    pub fn length(&self) -> f32 {
+        (self.point2.x - self.point1.x + self.point2.y - self.point1.y).sqrt()
+    }
+
     /// Returns the slope of this LineSegment.
     ///
     /// If the slope is completely vertical, this function will return f32::INFINITY, otherwise
@@ -471,5 +476,11 @@ mod tests {
           }
       }
 
+      // Passes if LineSegment::length() works
+      #[test]
+      fn line_length() {
+          let line = LineSegment::new(0., 0., 2., 2.);
+          assert_eq!(line.length(), 2.);
+      }
 
 }

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -109,7 +109,7 @@ impl Line {
         let slope = self.get_slope();
         match slope <= 1. {
             true => self.step_by_x_coordinates(),
-            false => self.step_by_x_coordinates()
+            false => self.step_by_y_coordinates()
         }
     }
 
@@ -125,6 +125,10 @@ impl Line {
         }
 
         result
+    }
+
+    fn step_by_y_coordinates(&self) -> Vec<(i32, i32)> {
+        vec![(0, 0)]
     }
 }
 

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -46,6 +46,16 @@ pub struct Point {
     pub y: f32,
 }
 
+impl Point {
+    fn x_less_than(&self, other: &Point) -> bool {
+        self.x < other.x
+    }
+
+    fn y_less_than(&self, other: &Point) -> bool {
+        self.y < other.y
+    }
+}
+
 impl PartialEq for Point {
     fn eq(&self, other: &Point) -> bool {
         self.x == other.x && self.y == other.y
@@ -57,8 +67,8 @@ impl PartialEq for Point {
 /// Defines a line by two points.
 #[derive(Debug, Copy, Clone)]
 pub struct Line {
-    point1: Point,
-    point2: Point,
+    pub point1: Point,
+    pub point2: Point,
 }
 
 impl Line {
@@ -149,6 +159,21 @@ impl PartialEq for Vector {
 #[cfg(test)]
 mod tests {
     use super::{Line, Point, Vector};
+
+    #[test]
+    fn point_lt() {
+        let p1 = Point{x: 0., y: 0.};
+        let p2 = Point{x: 1., y: 1.};
+        assert!(p1.x_less_than(&p2));
+    }
+
+    #[test]
+    #[should_panic]
+    fn point_lt2() {
+        let p1 = Point{x: 0., y: 0.};
+        let p2 = Point{x: 1., y: 1.};
+        assert!(p2.x_less_than(&p1));
+    }
 
     #[test]
     fn line_new() {

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -102,6 +102,30 @@ impl Line {
             y: self.point1.y + (mid_x * self.get_slope() ),
         }
     }
+
+    // Returns a Vector of coordinates indicating which pixels this line should color when
+    // rasterized.  The algorithm is a straight-forward DDA.
+    pub fn into_pixel_coordinates(&self) -> Vec<(i32, i32)> {
+        let slope = self.get_slope();
+        match slope <= 1. {
+            true => self.step_by_x_coordinates(),
+            false => self.step_by_x_coordinates()
+        }
+    }
+
+    fn step_by_x_coordinates(&self) -> Vec<(i32, i32)> {
+        let max_x = self.point1.x.max(self.point2.x) as i32;
+        let slope = self.get_slope();
+        let mut running_total_y = 0.;
+        let mut result = Vec::with_capacity(max_x as usize);
+        for x in 0..max_x {
+            running_total_y += slope;
+            let coordinate = (x, running_total_y.round() as i32);
+            result.push(coordinate);
+        }
+
+        result
+    }
 }
 
 /// ## Vector
@@ -202,6 +226,27 @@ mod tests {
         let line = Line::new(0., 0., 2., 2.);
         assert_eq!(line.get_midpoint(), Point{x: 1., y: 1.});
     }
+
+    #[test]
+    fn line_into_pixel_coordinates_slope_lt_one() {
+        // The following coordinates were calculated by hand to be known pixels in the defined
+        // line.
+        let line = Line::new(0., 0., 20., 5.);
+        let expected = vec![
+            (0, 0),
+            (1, 1),
+            (2, 1),
+            (3, 1),
+            (4, 1),
+            (5, 2),
+        ];
+
+        let pixel_coordinates = line.into_pixel_coordinates();
+        for coordinate in expected {
+            assert!(pixel_coordinates.contains(&coordinate));
+        }
+    }
+
 
     #[test]
     fn vector_new() {

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -261,7 +261,6 @@ mod tests {
         assert_eq!(trap.b, b);
         assert_eq!(trap.c, c);
         assert_eq!(trap.d, d);
-
     }
 
     #[test]
@@ -275,6 +274,5 @@ mod tests {
         assert_eq!(trap.b, b);
         assert_eq!(trap.c, c);
         assert_eq!(trap.d, d);
-
     }
 }

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -35,7 +35,7 @@
 
 //! This module defines geometric structs and methods common to algorithms used throughout Cairus.
 
-use std::ops::Add;
+use std::ops::{Add, Sub};
 
 /// ## Point
 ///
@@ -53,6 +53,20 @@ impl Point {
 
     fn y_less_than(&self, other: &Point) -> bool {
         self.y < other.y
+    }
+}
+
+impl Add for Point {
+    type Output = Point;
+    fn add(self, rhs: Point) -> Point {
+        Point{x: self.x + rhs.x, y: self.y + rhs.y}
+    }
+}
+
+impl Sub for Point {
+    type Output = Point;
+    fn sub(self, rhs: Point) -> Point {
+        Point{x: self.x - rhs.x, y: self.y - rhs.y}
     }
 }
 
@@ -211,6 +225,18 @@ mod tests {
         let p1 = Point{x: 0., y: 0.};
         let p2 = Point{x: 1., y: 1.};
         assert!(p2.x_less_than(&p1));
+    }
+
+    #[test]
+    fn point_add() {
+        let p = Point{x: 1., y: 1.};
+        assert_eq!(p + p, Point{x: 2., y: 2.});
+    }
+
+    #[test]
+    fn point_sub() {
+        let p = Point{x: 1., y: 1.};
+        assert_eq!(p - p, Point{x: 0., y: 0.});
     }
 
     #[test]

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -36,6 +36,7 @@
 //! This module defines geometric structs and methods common to algorithms used throughout Cairus.
 
 use std::ops::{Add, Sub};
+use std::cmp::Ordering;
 
 /// ## Point
 ///
@@ -55,6 +56,32 @@ impl Point {
         self.y < other.y
     }
 }
+
+impl Ord for Point {
+    fn cmp(&self, other: &Point) -> Ordering {
+        if self.x < other.x {
+            Ordering::Less
+        } else if self.x == other.x {
+            if self.y < other.y {
+                Ordering::Less
+            } else if self.y == other.y {
+                Ordering::Equal
+            } else {
+                Ordering::Greater
+            }
+        } else {
+            Ordering::Greater
+        }
+    }
+}
+
+impl PartialOrd for Point {
+    fn partial_cmp(&self, other: &Point) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Eq for Point {}
 
 impl Add for Point {
     type Output = Point;
@@ -217,6 +244,13 @@ mod tests {
         let p1 = Point{x: 0., y: 0.};
         let p2 = Point{x: 1., y: 1.};
         assert!(p1.x_less_than(&p2));
+    }
+
+    #[test]
+    fn point_ordering_lt() {
+        let p1 = Point{x: 0., y: 0.};
+        let p2 = Point{x: 1., y: 1.};
+        assert!(p1 < p2);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,8 @@ mod surfaces;
 #[allow(dead_code)]
 mod common_geometry;
 
+#[allow(dead_code)]
+mod trapezoid_rasterizer;
 
 #[cfg(test)]
 mod tests {

--- a/src/surfaces.rs
+++ b/src/surfaces.rs
@@ -130,7 +130,7 @@ impl ImageSurface {
     }
 
     fn calculate_position(width: usize, x: usize, y: usize) -> usize {
-        (x * width + y).wrapping_sub(1)
+        y * width +x
     }
 }
 

--- a/src/surfaces.rs
+++ b/src/surfaces.rs
@@ -94,8 +94,8 @@ pub enum Type {
 pub struct ImageSurface {
     // base is just a collection of pixels
     base: Vec<Rgba>,
-    width: usize,
-    height: usize,
+    pub width: usize,
+    pub height: usize,
 }
 
 /// ImageSurface provides iter(), into_iter(), and iter_mut() so that when a Cairus context calls
@@ -103,7 +103,7 @@ pub struct ImageSurface {
 /// compositing operator to operate on them.  See `operators.rs` for those operations.
 impl ImageSurface {
     // Analagous to cairo_create(), you pass in a width and height and get in a surface in exchange.
-    fn create(width: usize, height: usize) -> ImageSurface {
+    pub fn create(width: usize, height: usize) -> ImageSurface {
         ImageSurface {
             base: vec![Rgba::new(0., 0., 0., 0.); width * height],
             width: width,
@@ -111,12 +111,26 @@ impl ImageSurface {
         }
     }
 
-    fn iter(&self) -> Iter<Rgba> {
+    pub fn iter(&self) -> Iter<Rgba> {
         self.base.iter()
     }
 
-    fn iter_mut(&mut self) -> IterMut<Rgba> {
+    pub fn iter_mut(&mut self) -> IterMut<Rgba> {
         self.base.iter_mut()
+    }
+
+    pub fn get(&self, x: usize, y: usize) -> Option<&Rgba> {
+        let position = ImageSurface::calculate_position(self.width, x, y);
+        self.base.get(position)
+    }
+
+    pub fn get_mut(&mut self, x: usize, y: usize) -> &mut Rgba {
+        let position = ImageSurface::calculate_position(self.width, x, y);
+        &mut self.base[position]
+    }
+
+    fn calculate_position(width: usize, x: usize, y: usize) -> usize {
+        (x * width + y).wrapping_sub(1)
     }
 }
 
@@ -227,5 +241,12 @@ mod tests {
         for pixel in destination {
             assert_eq!(pixel, expected);
         }
+    }
+
+    #[test]
+    fn image_surface_index() {
+        let destination = ImageSurface::create(100, 100);
+        let transparent_pixel = Rgba::new(0., 0., 0., 0.);
+        assert_eq!(*destination.get(0, 0).unwrap(), transparent_pixel);
     }
 }

--- a/src/surfaces.rs
+++ b/src/surfaces.rs
@@ -130,7 +130,7 @@ impl ImageSurface {
     }
 
     fn calculate_position(width: usize, x: usize, y: usize) -> usize {
-        y * width +x
+        y * width + x
     }
 }
 

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -90,17 +90,24 @@ impl Trapezoid {
     }
 
     // Returns a Vec<LineSegment> of the four lines that make up this Trapezoid.
-    fn get_lines(&self) -> Vec<LineSegment> {
+    fn lines(&self) -> Vec<LineSegment> {
         // TODO: This algorithm is probably not general!!! research further...
         //       MAKE USE OF bases() to figure out legs
-        let mut points = vec![self.a, self.b, self.c, self.d];
-        points.sort_by(|&a, &b| { a.x.partial_cmp(&b.x).unwrap() });
-        vec![
-            LineSegment::from_points(points[0], points[1]),
-            LineSegment::from_points(points[1], points[3]),
-            LineSegment::from_points(points[3], points[2]),
-            LineSegment::from_points(points[2], points[0]),
-        ]
+
+        let bases = self.bases();
+        if bases.len() == 2 {
+            vec![bases[0].0, bases[0].1, bases[1].0, bases[1].1]
+        } else {
+
+            let mut points = vec![self.a, self.b, self.c, self.d];
+            points.sort_by(|&a, &b| { a.x.partial_cmp(&b.x).unwrap() });
+            vec![
+                LineSegment::from_points(points[0], points[1]),
+                LineSegment::from_points(points[1], points[3]),
+                LineSegment::from_points(points[3], points[2]),
+                LineSegment::from_points(points[2], points[0]),
+            ]
+        }
     }
 
     /// Returns self's base line segments.
@@ -137,7 +144,7 @@ impl Trapezoid {
 
     fn contains_point(&self, point: &Point) -> bool {
         let mut crossing_count = 0;
-        for line in self.get_lines().iter() {
+        for line in self.lines().iter() {
             if ray_from_point_crosses_line(point, line) {
                 crossing_count += 1;
             }
@@ -221,6 +228,27 @@ mod tests {
         let line = LineSegment::new(2., 2., 3., 3.);
         assert!(ray_from_point_crosses_line(&p, &line));
     }
+
+
+    #[test]
+    fn trapezoid_rectangle_get_lines() {
+        let a = Point{x: 0., y: 0.};
+        let b = Point{x: 2., y: 0.};
+        let c = Point{x: 2., y: 2.};
+        let d = Point{x: 0., y: 2.};
+        let ab = LineSegment::from_points(a, b);
+        let bc = LineSegment::from_points(b, c);
+        let cd = LineSegment::from_points(a, b);
+        let da = LineSegment::from_points(b, c);
+
+        let trap = Trapezoid::from_points(a, b, c, d);
+        let lines = trap.lines();
+        assert!(lines.contains(&ab));
+        assert!(lines.contains(&bc));
+        assert!(lines.contains(&cd));
+        assert!(lines.contains(&da));
+    }
+
 
     #[test]
     fn point_in_trapezoid() {

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -103,4 +103,26 @@ mod tests {
         assert_eq!(trap.c, c);
         assert_eq!(trap.d, d);
     }
+
+    #[test]
+    fn trapezoid_get_lines() {
+        let a = Point{x: 0., y: 0.};
+        let b = Point{x: 0., y: 1.};
+        let c = Point{x: 1., y: 0.};
+        let d = Point{x: 1., y: 1.};
+        let point_vec = vec![a, b, c, d];
+
+        let trap = Trapezoid::from_points(a, b, c, d);
+        let lines = trap.get_lines();
+
+        assert_eq!(lines[0].point1, a);
+        assert_eq!(lines[0].point2, b);
+        assert_eq!(lines[1].point1, b);
+        assert_eq!(lines[1].point2, c);
+        assert_eq!(lines[2].point1, c);
+        assert_eq!(lines[2].point2, d);
+        assert_eq!(lines[3].point1, d);
+        assert_eq!(lines[3].point2, a);
+    }
+
 }

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -68,13 +68,68 @@ impl Trapezoid {
 
     // Returns a Vec<Line> of the four lines that make up this Trapezoid.
     fn get_lines(&self) -> Vec<Line> {
-        let mut ordered_points = vec![self.a, self.b, self.c, self.d];
-        ordered_points.sort();
+        // TODO: This algorithm is probably not general!!! research further...
+        let mut points = vec![self.a, self.b, self.c, self.d];
+        let mut all_possible_lines = Vec::with_capacity(4 * 4);
+
+        for p1 in points.iter() {
+            for p2 in points.iter() {
+                let temp = Line::from_points(*p1, *p2);
+                all_possible_lines.push(temp);
+            }
+        }
+
+        let mut parallel = Vec::new();
+        for l1 in all_possible_lines.iter() {
+            for l2 in all_possible_lines.iter() {
+                if l1.same_slope(&l2) {
+                    parallel.push((l1, l2));
+                    break;
+                }
+            }
+        }
+
+        let (line1, line2) = parallel.pop().unwrap();
+        match line1.get_slope() {
+            Some(slope) => {
+                if slope > 0. {
+                    let line1_least_x =
+                        if line1.point1.x < line1.point2.x {
+                            line1.point1
+                        } else {
+                            line1.point2
+                        };
+                    let line2_least_x =
+                        if line2.point1.x < line2.point2.x {
+                            line2.point1
+                        } else {
+                            line2.point2
+                        };
+                } else if slope >= 0. {
+
+                }
+            },
+            None => {
+                let line1_least_x =
+                    if line1.point1.x < line1.point2.x {
+                        line1.point1
+                    } else {
+                        line1.point2
+                    };
+                let line2_least_x =
+                    if line2.point1.x < line2.point2.x {
+                        line2.point1
+                    } else {
+                        line2.point2
+                    };
+            }
+        }
+
         vec![
-            Line::from_points(ordered_points[0], ordered_points[1]),
-            Line::from_points(ordered_points[1], ordered_points[3]),
-            Line::from_points(ordered_points[3], ordered_points[2]),
-            Line::from_points(ordered_points[2], ordered_points[0]),
+            Line::from_points(points[0], points[1]),
+            Line::from_points(points[1], points[3]),
+            Line::from_points(points[3], points[2]),
+            Line::from_points(points[2], points[0]),
         ]
     }
 
@@ -103,9 +158,16 @@ fn ray_from_point_crosses_line(point: &Point, line: &Line) -> bool {
         } else {
             // Find sign of x-crossing of point's ray and line
             let line_point = line.point1;
-            let b = line_point.y - line.get_slope() * line_point.x;
-            let x = (point.y - b) / line.get_slope();
-            x.is_sign_positive()
+            match line.get_slope() {
+                Some(slope) => {
+                    let b = line_point.y - slope * line_point.x;
+                    let x = (point.y - b) / slope;
+                    x.is_sign_positive()
+                },
+                None => {
+                    point.x.is_sign_positive()
+                },
+            }
         }
     } else {
             false

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -383,9 +383,6 @@ pub fn mask_from_trapezoids(trapezoids: &Vec<Trapezoid>, width: usize, height: u
                 }
             }
 
-            if pixel.x == 3 && pixel.y == 3 {
-                println!("x, y = {}, {} --- successes: {}", pixel.x, pixel.y, successes);
-            }
             rgba.alpha += successes as f32 / 255.;
             rgba.alpha.max(1.);
          }

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -168,7 +168,73 @@ impl Trapezoid {
 
         crossing_count % 2 != 0
     }
+
+    fn extent(&self) -> Extent {
+        let mut smallest_x = self.a.x;
+        let mut biggest_x = self.a.x;
+        let mut smallest_y = self.a.y;
+        let mut biggest_y = self.a.y;
+        let points = vec![self.a, self.b, self.c, self.d];
+        for point in points {
+            if point.x < smallest_x {
+                smallest_x = point.x;
+            }
+
+            if point.x > biggest_x {
+                biggest_x = point.x;
+            }
+
+            if point.y < smallest_y {
+                smallest_y = point.y;
+            }
+
+            if point.y > biggest_y {
+                biggest_y = point.y;
+            }
+        }
+
+        let top_left = Point{x: smallest_x, y: biggest_y};
+        let bottom_right = Point{x: biggest_x, y: smallest_y};
+        Extent::new(top_left, bottom_right)
+    }
 }
+
+
+/// # Extent
+///
+/// An extent is the smallest possible rectangle that could surround a given Trapezoid
+struct Extent {
+    top_left: Point,
+    bottom_right: Point,
+}
+
+impl Extent {
+    fn new(top_left: Point, bottom_right: Point) -> Extent {
+        Extent {
+            top_left: top_left,
+            bottom_right: bottom_right,
+        }
+    }
+
+    fn width(&self) -> f32 {
+        (self.top_left.x - self.bottom_right.x).abs()
+    }
+
+    fn height(&self) -> f32 {
+        (self.top_left.y - self.bottom_right.y).abs()
+    }
+
+    fn top_left(&self) -> &Point {
+        &self.top_left
+    }
+
+    fn bottom_right(&self) -> &Point {
+        &self.bottom_right
+    }
+
+
+}
+
 
 /// Returns true if a ray running along the x-axis intersects the line `line`.
 fn ray_from_point_crosses_line(point: &Point, line: &LineSegment) -> bool {
@@ -350,5 +416,52 @@ mod tests {
         let base2 = LineSegment::from_points(c, d);
         let base_pair = TrapezoidBasePair(base1, base2);
         assert_eq!(base_pair.slope(), 1.);
+    }
+
+
+    #[test]
+    fn trapezoid_extent_width() {
+        let a = Point{x: 0., y: 0.};
+        let b = Point{x: 1., y: 0.};
+        let c = Point{x: 1., y: 1.};
+        let d = Point{x: 0., y: 1.};
+        let trap = Trapezoid::from_points(a, b, c, d);
+        let extent = trap.extent();
+        assert_eq!(extent.width(), 1.);
+    }
+
+
+    #[test]
+    fn trapezoid_extent_height() {
+        let a = Point{x: 0., y: 0.};
+        let b = Point{x: 1., y: 0.};
+        let c = Point{x: 1., y: 1.};
+        let d = Point{x: 0., y: 1.};
+        let trap = Trapezoid::from_points(a, b, c, d);
+        let extent = trap.extent();
+        assert_eq!(extent.height(), 1.);
+    }
+
+
+    #[test]
+    fn trapezoid_extent_top_left() {
+        let a = Point{x: 0., y: 0.};
+        let b = Point{x: 1., y: 0.};
+        let c = Point{x: 1., y: 1.};
+        let d = Point{x: 0., y: 1.};
+        let trap = Trapezoid::from_points(a, b, c, d);
+        let extent = trap.extent();
+        assert_eq!(*extent.top_left(), d);
+    }
+
+    #[test]
+    fn trapezoid_extent_bottom_right() {
+        let a = Point{x: 0., y: 0.};
+        let b = Point{x: 1., y: 0.};
+        let c = Point{x: 1., y: 1.};
+        let d = Point{x: 0., y: 1.};
+        let trap = Trapezoid::from_points(a, b, c, d);
+        let extent = trap.extent();
+        assert_eq!(*extent.bottom_right(), b);
     }
 }

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -127,12 +127,8 @@ use std::collections::HashMap;
 /// ### Panics
 /// `fn Trapezoid::from_bases` will panic if the LineSegments are not parallel.
 ///
-/// TODO: Test edge-cases
-/// TODO: Change Struct to be represented by base LineSegments instead of points
 /// TODO: Implement `fn points()` or `fn a()`, `fn b()` , etc...
 /// TODO: Test/verify degenerate Trapezoid (a triangle) is still valid
-/// TODO: Investigate optimizing and benching rasterization
-/// TODO: Change tuple coordinates to Point struct for name clarity
 pub struct Trapezoid {
     lines: Vec<LineSegment>
 }
@@ -404,9 +400,9 @@ mod tests {
         assert!(hasd);
     }
 
-    // Test that trapezoid can be constructed from bases
+    // Passes if bases_from_points returns the correct bases pairs
     #[test]
-    fn trapezoid_from_bases() {
+    fn test_bases_from_points() {
         let a = Point{x: 0., y: 0.};
         let b = Point{x: 4., y: 0.};
         let c = Point{x: 2., y: 2.};
@@ -592,5 +588,19 @@ mod tests {
         assert_eq!(rgba.alpha, 1.);
         let rgba = mask.get(3, 3).unwrap();
         assert!(rgba.alpha > 0.9);
+    }
+
+    // Passes if a degenerate trapezoid (a triangle) functions correctly
+    #[test]
+    fn degenerate_trapezoid_works() {
+        let a = Point{x: 0., y: 0.};
+        let b = Point{x: 4., y: 0.};
+        let base1 = LineSegment{point1: a, point2: b};
+
+        let c = Point{x: 3., y: 3.};
+        let d = Point{x: 3., y: 3.};
+        let base2 = LineSegment{point1: c, point2: d};
+
+        let trapezoid = Trapezoid::from_bases(base1, base2);
     }
 }

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -141,6 +141,9 @@ impl TrapezoidBasePair {
 /// must cover every single subpixel point inside that pixel.  If it doesn't cover any subpixel,
 /// the pixel is left transparent.
 ///
+///  See `fn ray_from_point_crosses_line` for ray intersection algorithm, and
+///  `fn Trapezoid::contains_point` for how it is used to determine if a point is in a trapezoid.
+///
 /// TODO: Reference the DDA algorithm and its usage
 
 

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -1,0 +1,106 @@
+/*
+ * Cairus - a reimplementation of the cairo graphics library in Rust
+ *
+ * Copyright © 2017 CairusOrg
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it either under the terms of the GNU Lesser General Public
+ * License version 2.1 as published by the Free Software Foundation
+ * (the "LGPL") or, at your option, under the terms of the Mozilla
+ * Public License Version 2.0 (the "MPL"). If you do not alter this
+ * notice, a recipient may use your version of this file under either
+ * the MPL or the LGPL.
+ *
+ * You should have received a copy of the LGPL along with this library
+ * in the file LICENSE-LGPL-2_1; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02110-1335, USA
+ * You should have received a copy of the MPL along with this library
+ * in the file LICENSE-MPL-2_0
+ *
+ * The contents of this file are subject to the Mozilla Public License
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY
+ * OF ANY KIND, either express or implied. See the LGPL or the MPL for
+ * the specific language governing rights and limitations.
+ *
+ * The Original Code is the cairus graphics library.
+ *
+ * Contributor(s):
+ *	Bobby Eshleman <bobbyeshleman@gmail.com>
+ *
+ */
+
+use common_geometry::Point;
+
+/// ## Trapezoid
+///
+/// Defines a trapezoid as four points.
+struct Trapezoid {
+    a: Point,
+    b: Point,
+    c: Point,
+    d: Point,
+}
+
+impl Trapezoid {
+    // Returns a new Trapezoid defined by coordinates.
+    fn new(ax: f32, ay: f32, bx: f32, by: f32, cx: f32, cy: f32, dx: f32, dy: f32) -> Trapezoid {
+        Trapezoid {
+            a: Point {x: ax, y: ay},
+            b: Point {x: bx, y: by},
+            c: Point {x: cx, y: cy},
+            d: Point {x: dx, y: dy},
+        }
+    }
+
+    // Returns a new Trapezoid defined by points.
+    fn from_points(a: Point, b: Point, c: Point, d: Point) -> Trapezoid {
+        Trapezoid {
+            a: a,
+            b: b,
+            c: c,
+            d: d,
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::{Trapezoid};
+    use common_geometry::Point;
+
+    #[test]
+    fn trapezoid_new() {
+        let trap = Trapezoid::new(0., 0.,
+                                  0., 1.,
+                                  1., 0.,
+                                  1., 1.);
+
+        let a = Point{x: 0., y: 0.};
+        let b = Point{x: 0., y: 1.};
+        let c = Point{x: 1., y: 0.};
+        let d = Point{x: 1., y: 1.};
+
+        assert_eq!(trap.a, a);
+        assert_eq!(trap.b, b);
+        assert_eq!(trap.c, c);
+        assert_eq!(trap.d, d);
+    }
+
+    #[test]
+    fn trapezoid_from_points() {
+        let a = Point{x: 0., y: 0.};
+        let b = Point{x: 0., y: 1.};
+        let c = Point{x: 1., y: 0.};
+        let d = Point{x: 1., y: 1.};
+        let trap = Trapezoid::from_points(a, b, c, d);
+        assert_eq!(trap.a, a);
+        assert_eq!(trap.b, b);
+        assert_eq!(trap.c, c);
+        assert_eq!(trap.d, d);
+    }
+}

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -33,7 +33,7 @@
  *
  */
 
-use common_geometry::{Point, Line};
+use common_geometry::{Point, LineSegment};
 
 /// ## Trapezoid
 ///
@@ -66,70 +66,16 @@ impl Trapezoid {
         }
     }
 
-    // Returns a Vec<Line> of the four lines that make up this Trapezoid.
-    fn get_lines(&self) -> Vec<Line> {
+    // Returns a Vec<LineSegment> of the four lines that make up this Trapezoid.
+    fn get_lines(&self) -> Vec<LineSegment> {
         // TODO: This algorithm is probably not general!!! research further...
         let mut points = vec![self.a, self.b, self.c, self.d];
-        let mut all_possible_lines = Vec::with_capacity(4 * 4);
-
-        for p1 in points.iter() {
-            for p2 in points.iter() {
-                let temp = Line::from_points(*p1, *p2);
-                all_possible_lines.push(temp);
-            }
-        }
-
-        let mut parallel = Vec::new();
-        for l1 in all_possible_lines.iter() {
-            for l2 in all_possible_lines.iter() {
-                if l1.same_slope(&l2) {
-                    parallel.push((l1, l2));
-                    break;
-                }
-            }
-        }
-
-        let (line1, line2) = parallel.pop().unwrap();
-        match line1.get_slope() {
-            Some(slope) => {
-                if slope > 0. {
-                    let line1_least_x =
-                        if line1.point1.x < line1.point2.x {
-                            line1.point1
-                        } else {
-                            line1.point2
-                        };
-                    let line2_least_x =
-                        if line2.point1.x < line2.point2.x {
-                            line2.point1
-                        } else {
-                            line2.point2
-                        };
-                } else if slope >= 0. {
-
-                }
-            },
-            None => {
-                let line1_least_x =
-                    if line1.point1.x < line1.point2.x {
-                        line1.point1
-                    } else {
-                        line1.point2
-                    };
-                let line2_least_x =
-                    if line2.point1.x < line2.point2.x {
-                        line2.point1
-                    } else {
-                        line2.point2
-                    };
-            }
-        }
 
         vec![
-            Line::from_points(points[0], points[1]),
-            Line::from_points(points[1], points[3]),
-            Line::from_points(points[3], points[2]),
-            Line::from_points(points[2], points[0]),
+            LineSegment::from_points(points[0], points[1]),
+            LineSegment::from_points(points[1], points[3]),
+            LineSegment::from_points(points[3], points[2]),
+            LineSegment::from_points(points[2], points[0]),
         ]
     }
 
@@ -145,7 +91,7 @@ impl Trapezoid {
 }
 
 /// Returns true if a ray running along the x-axis intersects the line `line`.
-fn ray_from_point_crosses_line(point: &Point, line: &Line) -> bool {
+fn ray_from_point_crosses_line(point: &Point, line: &LineSegment) -> bool {
     let p1 = line.point1 - *point;
     let p2 = line.point2 - *point;
     let origin = Point{x: 0., y: 0.};
@@ -158,7 +104,7 @@ fn ray_from_point_crosses_line(point: &Point, line: &Line) -> bool {
         } else {
             // Find sign of x-crossing of point's ray and line
             let line_point = line.point1;
-            match line.get_slope() {
+            match line.slope() {
                 Some(slope) => {
                     let b = line_point.y - slope * line_point.x;
                     let x = (point.y - b) / slope;
@@ -177,7 +123,7 @@ fn ray_from_point_crosses_line(point: &Point, line: &Line) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{Trapezoid, ray_from_point_crosses_line};
-    use common_geometry::{Point, Line};
+    use common_geometry::{Point, LineSegment};
 
     #[test]
     fn trapezoid_new() {
@@ -233,7 +179,7 @@ mod tests {
     #[test]
     fn crossings_test() {
         let p = Point{x: 1., y: 1.};
-        let line = Line::new(0., 0., 2., 2.);
+        let line = LineSegment::new(0., 0., 2., 2.);
         assert!(ray_from_point_crosses_line(&p, &line));
     }
 
@@ -241,7 +187,7 @@ mod tests {
     #[should_panic]
     fn crossings_test2() {
         let p = Point{x: 1., y: 1.};
-        let line = Line::new(2., 2., 3., 3.);
+        let line = LineSegment::new(2., 2., 3., 3.);
         assert!(ray_from_point_crosses_line(&p, &line));
     }
 

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -92,6 +92,7 @@ impl Trapezoid {
     // Returns a Vec<LineSegment> of the four lines that make up this Trapezoid.
     fn get_lines(&self) -> Vec<LineSegment> {
         // TODO: This algorithm is probably not general!!! research further...
+        //       MAKE USE OF bases() to figure out legs
         let mut points = vec![self.a, self.b, self.c, self.d];
         points.sort_by(|&a, &b| { a.x.partial_cmp(&b.x).unwrap() });
         vec![

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -64,6 +64,15 @@ impl TrapezoidBasePair {
 /// ## Trapezoid
 ///
 /// Defines a trapezoid as four points.
+///
+/// TODO: Refactor
+/// TODO: Test edge-cases
+/// TODO: Implement `fn from_bases(LineSegment, LineSegment)`
+/// TODO: Implement checking for constructors
+/// TODO: Change Struct to be represented by base LineSegments instead of points
+/// TODO: Implement `fn points()` or `fn a()`, `fn b()` , etc...
+/// TODO: Test/verify degenerate Trapezoid (a triangle) is still valid
+/// TODO: Investigate optimizing and benching rasterization
 struct Trapezoid {
     a: Point,
     b: Point,
@@ -72,6 +81,8 @@ struct Trapezoid {
 }
 
 impl Trapezoid {
+
+
     // Returns a new Trapezoid defined by coordinates.
     fn new(ax: f32, ay: f32, bx: f32, by: f32, cx: f32, cy: f32, dx: f32, dy: f32) -> Trapezoid {
         Trapezoid {

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -628,5 +628,8 @@ mod tests {
         let mask = mask_from_trapezoids(&trapezoids, 10, 10);
         let rgba = mask.get(2, 1);
         assert!(rgba.unwrap().alpha > 0.);
+
+        let rgba = mask.get(1, 9);
+        assert!(rgba.unwrap().alpha == 0.);
     }
 }

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -204,7 +204,7 @@ impl Trapezoid {
 
 /// # Extent
 ///
-/// An extent is the smallest possible rectangle that could surround a given Trapezoid
+/// An extent is the smallest possible rectangle that could surround a given Trapezoid.
 /// Points go in counter-clockwise order.  `a` is least x and least y, b is most x and least y, etc...
 struct Extent {
     a: Point,

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -88,24 +88,22 @@ impl TrapezoidBasePair {
 ///        Pixel                                           Subpixel grid
 ///
 /// +--------------------------+                   X--X -X--X---X---X---X--X--X
-/// |                          |                   X  X  X  X   X   X   X  X  X
 /// |                          |                   |                          |
+/// |                          |                   X  X  X  X   X   X   X  X  X
 /// |                          |    into point     |                          |
 /// |                          |    sample         X  X  X  X   X   X   X  X  X
 /// |                          |    grid           |                          |
 /// |                          |   +------------>  X  X  X  X   X   X   X  X  X
 /// |                          |                   |                          |
-/// |                          |                   |                          |
 /// |                          |                   X  X  X  X   X   X   X  X  X
+/// |                          |                   |                          |
 /// |                          |                   X  X  X  X   X   X   X  X  X
 /// |                          |                   |                          |
 /// +--------------------------+                   X--X -X--X---X---X---X--X--X
 ///
-///                                            note: This isn't a uniform distribution, it is just
-///                                                  illustrative of sampling points.
 ///
 ///     Cairus iterates through each X in the Subpixel grid above, and checks if that X point is
-/// inside the trapezoid.  If it is, the opacity of that pixel will increase.
+/// inside the trapezoid.  If it is, the opacity of the original pixel will increase.
 ///
 ///  See the `fn Pixel::sample_points()` function for the implementation.
 ///

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -33,7 +33,7 @@
  *
  */
 
-use common_geometry::Point;
+use common_geometry::{Point, Line};
 
 /// ## Trapezoid
 ///
@@ -64,6 +64,16 @@ impl Trapezoid {
             c: c,
             d: d,
         }
+    }
+
+    // Returns a Vec<Line> of the four lines that make up this Trapezoid.
+    fn get_lines(&self) -> Vec<Line> {
+        vec![
+            Line::from_points(self.a, self.b),
+            Line::from_points(self.b, self.c),
+            Line::from_points(self.c, self.d),
+            Line::from_points(self.d, self.a),
+        ]
     }
 }
 
@@ -111,18 +121,16 @@ mod tests {
         let c = Point{x: 1., y: 0.};
         let d = Point{x: 1., y: 1.};
         let point_vec = vec![a, b, c, d];
-
         let trap = Trapezoid::from_points(a, b, c, d);
-        let lines = trap.get_lines();
 
-        assert_eq!(lines[0].point1, a);
-        assert_eq!(lines[0].point2, b);
-        assert_eq!(lines[1].point1, b);
-        assert_eq!(lines[1].point2, c);
-        assert_eq!(lines[2].point1, c);
-        assert_eq!(lines[2].point2, d);
-        assert_eq!(lines[3].point1, d);
-        assert_eq!(lines[3].point2, a);
+        let mut points = Vec::new();
+        for line in trap.get_lines() {
+            points.push(line.point1);
+            points.push(line.point2);
+        }
+
+        for point in point_vec {
+            assert!(points.contains(&point));
+        }
     }
-
 }

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -143,7 +143,9 @@ impl Trapezoid {
 
     // Returns a new Trapezoid from two bases
     fn from_bases(base1: LineSegment, base2: LineSegment) -> Trapezoid {
-        if base1.slope() != base2.slope() {
+        if base1.length() != 0. &&
+           base2.length() != 0. &&
+           base1.slope() != base2.slope() {
             panic!("Trapezoid::from_bases() can only be called on LineSegments with equal slope!");
         }
 
@@ -269,8 +271,7 @@ fn bases_from_points(a: Point, b: Point, c: Point, d: Point) -> Vec<TrapezoidBas
 // Returns a Vec<LineSegment> of the four lines that make up a Trapezoid with bases base1 and
 // base2.
 fn lines_from_bases(base1: LineSegment, base2: LineSegment) -> Vec<LineSegment> {
-    let slope = base1.slope(); // TrapezoidBasePair, not a LineSegment
-    if slope == f32::INFINITY {
+    if base1.slope() == f32::INFINITY {
         let top_leg = LineSegment::from_points(base1.highest_point(), base2.highest_point());
         let bottom_leg = LineSegment::from_points(base1.lowest_point(), base2.lowest_point());
         vec![bottom_leg, base1, top_leg, base2]
@@ -325,7 +326,7 @@ fn ray_from_point_crosses_line(point: &Point, line: &LineSegment) -> bool {
             x.is_sign_positive()
         }
     } else {
-            false
+        false
     }
 }
 
@@ -602,5 +603,10 @@ mod tests {
         let base2 = LineSegment{point1: c, point2: d};
 
         let trapezoid = Trapezoid::from_bases(base1, base2);
+
+        let internal_point = Point{x: 3., y: 2.};
+        let external_point = Point{x: 2., y: 2.5};
+        assert!(trapezoid.contains_point(&internal_point));
+        assert!(!trapezoid.contains_point(&external_point));
     }
 }

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -92,8 +92,6 @@ impl Trapezoid {
 
     // Returns a Vec<LineSegment> of the four lines that make up this Trapezoid.
     fn lines(&self) -> Vec<LineSegment> {
-        // TODO: This algorithm is probably not general!!! research further...
-        //       MAKE USE OF bases() to figure out legs
         // TODO: Organize lines to be returned in counter-clockwise order
         let bases = self.bases();
         if bases.len() == 2 {

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -77,11 +77,22 @@ impl Trapezoid {
     }
 }
 
+/// Returns true if a ray running along the x-axis intersects the line `line`.
+fn ray_from_point_crosses_line(point: &Point, line: &Line) -> bool {
+    let p1 = line.point1 - *point;
+    let p2 = line.point2 - *point;
+    let point_is_on_vertex = p1 == *point && p2 == *point;
+    if point_is_on_vertex  {
+        true
+    } else {
+        p1.y.signum() != p2.y.signum()
+    }
+}
 
 #[cfg(test)]
 mod tests {
-    use super::{Trapezoid};
-    use common_geometry::Point;
+    use super::{Trapezoid, ray_from_point_crosses_line};
+    use common_geometry::{Point, Line};
 
     #[test]
     fn trapezoid_new() {
@@ -132,5 +143,21 @@ mod tests {
         for point in point_vec {
             assert!(points.contains(&point));
         }
+    }
+
+
+    #[test]
+    fn crossings_test() {
+        let p = Point{x: 1., y: 1.};
+        let line = Line::new(0., 0., 2., 2.);
+        assert!(ray_from_point_crosses_line(&p, &line));
+    }
+
+    #[test]
+    #[should_panic]
+    fn crossings_test2() {
+        let p = Point{x: 1., y: 1.};
+        let line = Line::new(2., 2., 3., 3.);
+        assert!(ray_from_point_crosses_line(&p, &line));
     }
 }

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -35,6 +35,29 @@
 
 use common_geometry::{Point, LineSegment};
 
+// Defines the a collection for holding a Trapezoid's bases.
+//
+// A Trapezoid's base line segments are always parallel.
+// If a trapezoid is a rectangle, it has two base pairs, otherwise just one
+//
+// Warning! -  TrapezoidBasePair doesn't check for parallelity, it assumes it is being passed
+//             parallel line segments.
+struct TrapezoidBasePair(LineSegment, LineSegment);
+
+// Returns true if TrapezoidBasePairs have the same LineSegments, disregarding order.
+impl PartialEq for TrapezoidBasePair {
+    fn eq(&self, other: &TrapezoidBasePair) -> bool {
+        (self.0 == other.0 && self.1 == other.1) ||
+        (self.0 == other.1 && self.1 == other.0)
+    }
+}
+
+impl TrapezoidBasePair {
+    fn slope(&self) -> f32 {
+        self.0.slope()
+    }
+}
+
 /// ## Trapezoid
 ///
 /// Defines a trapezoid as four points.
@@ -43,17 +66,6 @@ struct Trapezoid {
     b: Point,
     c: Point,
     d: Point,
-}
-
-// A TrapezoidBase is always two parallel line segments
-// If a trapezoid is a rectangle, it has two base pairs, otherwise just one
-struct TrapezoidBasePair(LineSegment, LineSegment);
-
-impl PartialEq for TrapezoidBasePair {
-    fn eq(&self, other: &TrapezoidBasePair) -> bool {
-        (self.0 == other.0 && self.1 == other.1) ||
-        (self.0 == other.1 && self.1 == other.0)
-    }
 }
 
 impl Trapezoid {
@@ -235,5 +247,18 @@ mod tests {
         let base2 = LineSegment::from_points(c, d);
         let base_pair = TrapezoidBasePair(base1, base2);
         assert!(bases.contains(&base_pair));
+    }
+
+    #[test]
+    fn trapezoid_base_pair_slope() {
+        let a = Point{x: 0., y: 0.};
+        let b = Point{x: 1., y: 1.};
+        let c = Point{x: 1., y: 0.};
+        let d = Point{x: 2., y: 1.};
+
+        let base1 = LineSegment::from_points(a, b);
+        let base2 = LineSegment::from_points(c, d);
+        let base_pair = TrapezoidBasePair(base1, base2);
+        assert_eq!(base_pair.slope(), 1.);
     }
 }

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -90,6 +90,11 @@ impl Trapezoid {
         ]
     }
 
+    /// Returns self's base line segments.
+    ///
+    /// A Trapezoid's base line segments are the parallel lines that form the Trapezoid.
+    /// If the returned Vec is of length 1, it is a normal trapezoid.
+    /// If the returned Vec is of length 2, it is a rectangle.
     fn bases(&self) -> Vec<TrapezoidBasePair> {
         let mut points = vec![self.a, self.b, self.c, self.d];
         points.sort_by(|&a, &b| { a.x.partial_cmp(&b.x).unwrap() });
@@ -101,7 +106,6 @@ impl Trapezoid {
                  possible_lines.push(line);
             }
         }
-
 
         let mut base_pairs = Vec::new();
         for outer in 0..possible_lines.len() {
@@ -125,6 +129,7 @@ impl Trapezoid {
                 crossing_count += 1;
             }
         }
+
         crossing_count % 2 != 0
     }
 }

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -97,42 +97,24 @@ impl Trapezoid {
         if bases.len() == 2 {
             vec![bases[0].0, bases[0].1, bases[1].0, bases[1].1]
         } else {
-            let mut lines = vec![bases[0].0, bases[0].1];
-            let slope = bases[0].slope();
+            let base = &bases[0];
+            let mut lines = vec![base.0, base.1];
+            let slope = bases[0].slope(); // TrapezoidBasePair, not a LineSegment
             if slope == f32::INFINITY {
-                let (highest_from_base0, lowest_from_base0) =
-                    if lines[0].point1.y > lines[0].point2.y {
-                        (lines[0].point1, lines[0].point2)
-                    } else {
-                        (lines[0].point2, lines[0].point1)
-                };
-
-                let (highest_from_base1, lowest_from_base1) =
-                    if lines[1].point1.y > lines[1].point2.y {
-                        (lines[1].point1, lines[1].point2)
-                    } else {
-                        (lines[1].point2, lines[1].point1)
-                };
+                let highest_from_base0 = base.0.highest_point();
+                let lowest_from_base0 = base.0.lowest_point();
+                let highest_from_base1 = base.1.highest_point();
+                let lowest_from_base1 = base.1.lowest_point();
 
                 let top_leg = LineSegment::from_points(highest_from_base0, highest_from_base1);
                 let bottom_leg = LineSegment::from_points(lowest_from_base0, lowest_from_base1);
                 lines.push(top_leg);
                 lines.push(bottom_leg);
-
             } else {
-                let (leftmost_from_base0, rightmost_from_base0) =
-                    if lines[0].point1.x < lines[0].point2.x {
-                        (lines[0].point1, lines[0].point2)
-                    } else {
-                        (lines[0].point2, lines[0].point1)
-                };
-
-                let (leftmost_from_base1, rightmost_from_base1) =
-                    if lines[1].point1.x < lines[1].point2.x {
-                        (lines[1].point1, lines[1].point2)
-                    } else {
-                        (lines[1].point2, lines[1].point1)
-                };
+                let leftmost_from_base0 = base.0.leftmost_point();
+                let rightmost_from_base0 = base.0.rightmost_point();
+                let leftmost_from_base1 = base.1.leftmost_point();
+                let rightmost_from_base1 = base.1.rightmost_point();
 
                 let left_leg = LineSegment::from_points(leftmost_from_base0, leftmost_from_base1);
                 let right_leg = LineSegment::from_points(rightmost_from_base0, rightmost_from_base1);

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -624,10 +624,9 @@ mod tests {
         }
     }
 
-    // Tests that the returned ImageSurface is correct.
-    // This test assumes the Trapezoid::lines() is functioning correctly.
-    // We check that the pixels in between the outline of the Trapezoid (non-inclusive)
-    // have alpha values that are not zero.
+    // Tests that a sample of pixels internal to the trapezoid are at least somewhat opaque
+    // (i.e., alpha > 0), and that a sampling of pixels external to the trapezoid are transparent
+    // (i.e., alpha == 0).
     #[test]
     fn mask_from_single_trapezoid() {
         let a = Point{x: 0., y: 0.};
@@ -637,10 +636,19 @@ mod tests {
         let trap = Trapezoid::from_points(a, b, c, d);
         let trapezoids = vec![trap];
         let mask = mask_from_trapezoids(&trapezoids, 10, 10);
-        let rgba = mask.get(2, 1);
-        assert!(rgba.unwrap().alpha > 0.);
 
-        let rgba = mask.get(1, 9);
-        assert!(rgba.unwrap().alpha == 0.);
+        // filled_pixels is the coordinates for pixels that should be filled (or somewhat opaque)
+        let filled_pixels = vec![(2, 1), (8, 1), (5, 8), (7, 0)];
+        for (x, y) in filled_pixels {
+            let rgba = mask.get(x, y).unwrap();
+            assert!(rgba.alpha > 0.);
+        }
+
+        // transparent_pixels is the coordinates for pixels that should be transparent
+        let transparent_pixels = vec![(1, 9), (10, 2), (0, 2), (3, 9), (9, 9)];
+        for (x, y) in transparent_pixels {
+            let rgba = mask.get(x, y).unwrap();
+            assert_eq!(rgba.alpha, 0.);
+        }
     }
 }


### PR DESCRIPTION
This implements a near final stage of the stroke implementation.  The primary function here is `mask_from_trapezoids` which returns a mask of a given size.  Using the `operator_in` operator with the source rgba, and the mask as a destination will eliminate the rgba color from any location outside of the source.  The next step is just apply the `operator_over` onto the destination.  That is the final stroke.

There are some smarter algorithmic choices that could be (and eventually should be) made in this module.  For example, the `into_pixels` function should return an iterator because it will be faster to retrieve those values _while_ iterating, instead of creating an array first (iterating anyways) and then iterating through it again later when the pixel coordinates actually get used. I'm just issuing this request now, because there maybe somewhere wiser for me to place my effort.  If we'd like to see some of these changes, I'd be happy to make them before the merge.