### PR TITLE
Adds tests for lines of code that were not previously covered

### DIFF
--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -305,10 +305,15 @@ mod tests {
         let p1 = Point{x: 0., y: 0.};
         let p2 = Point{x: 1., y: 1.};
         let line = LineSegment::from_points(p1, p2);
+        let line_rev = LineSegment::from_points(p2, p1);
         assert_eq!(line.leftmost_point(), p1);
+        assert_eq!(line_rev.leftmost_point(), p1);
         assert_eq!(line.lowest_point(), p1);
+        assert_eq!(line_rev.lowest_point(), p1);
         assert_eq!(line.rightmost_point(), p2);
+        assert_eq!(line_rev.rightmost_point(), p2);
         assert_eq!(line.highest_point(), p2);
+        assert_eq!(line_rev.highest_point(), p2);
     }
 
     // Tests that LineSegment Eq implementation is working

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -50,7 +50,7 @@
 //!          the destination opaque as well.
 //! * Source - Overwrites the destination with the source. Result color & alpha is equal to source.
 //! * In - The destination object is removed and the source object is only drawn where the
-//! destination was. 
+//! destination was.
 //! Descriptions/formulas for Cairo operators:
 //! [Cairo Operators](https://www.cairographics.org/operators/)
 
@@ -196,7 +196,7 @@ mod tests {
     fn test_over_operator_semi_transparent_source() {
         let source = Rgba::new(1., 0., 0., 0.5);
         let mut destination = Rgba::new(0., 1., 0., 0.5);
-        operator_over(&source, &mut destination);
+        fetch_operator(&Operator::Over)(&source, &mut destination);
 
         // This result was computed manually to be correct, and then modified to match Rust's
         // default floating point decimal place rounding.
@@ -222,7 +222,7 @@ mod tests {
     fn test_source_operator_semi_transparent_source() {
         let source = Rgba::new(1., 0., 0., 0.5);
         let mut destination = Rgba::new(0., 1., 0.5, 0.8);
-        operator_source(&source, &mut destination);
+        fetch_operator(&Operator::Source)(&source, &mut destination);
 
         assert_eq!(destination, Rgba::new(1., 0., 0., 0.5));
     }
@@ -246,13 +246,13 @@ mod tests {
     #[test]
     fn test_in_operator_semi_transparent_source() {
         let source = Rgba{
-            red:0.5, 
-            green:0.5, 
-            blue:0.5, 
+            red:0.5,
+            green:0.5,
+            blue:0.5,
             alpha:0.5
         };
         let mut destination = Rgba::new(0., 1., 0., 0.5);
-        operator_in(&source, &mut destination);
+        fetch_operator(&Operator::In)(&source, &mut destination);
         let test_rgba = Rgba{
             red:0.5,
             green:0.5,
@@ -267,8 +267,8 @@ mod tests {
         let source = Rgba::new(0.5, 0.5, 0.5, 1.);
         let mut destination = Rgba::new(1., 1., 1., 0.5);
         operator_in(&source, &mut destination);
-        let test_rgba =  Rgba{ 
-            red:0.5, 
+        let test_rgba =  Rgba{
+            red:0.5,
             green:0.5,
             blue:0.5,
             alpha:0.5
@@ -279,9 +279,9 @@ mod tests {
     #[test]
     fn test_in_operator_opaque_destination() {
         let source = Rgba{
-            red:0.25, 
-            green:0.25, 
-            blue:0.25, 
+            red:0.25,
+            green:0.25,
+            blue:0.25,
             alpha:0.25
         };
         let mut destination = Rgba::new(1.0, 1.0, 1.0, 1.0);
@@ -298,9 +298,9 @@ mod tests {
     #[test]
     fn test_in_operator_transparent_destination() {
         let source = Rgba{
-            red:0.5, 
-            green:0.5, 
-            blue:0.5, 
+            red:0.5,
+            green:0.5,
+            blue:0.5,
             alpha:0.25
         };
         let mut destination = Rgba::new(1.0, 1.0, 1.0, 0.0);

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -609,4 +609,18 @@ mod tests {
         assert!(trapezoid.contains_point(&internal_point));
         assert!(!trapezoid.contains_point(&external_point));
     }
+
+    #[test]
+    #[should_panic]
+    fn trap_from_bases_panics_on_non_parallel() {
+        let a = Point{x: 0., y: 0.};
+        let b = Point{x: 1., y: 1.};
+        let base1 = LineSegment{point1: a, point2: b};
+
+        let c = Point{x: 0., y: 0.};
+        let d = Point{x: 1., y: 2.};
+        let base2 = LineSegment{point1: c, point2: d};
+
+        let _ = Trapezoid::from_bases(base1, base2);
+    }
 }


### PR DESCRIPTION
- `common_geometry.rs`:
  - The else conditions in the [(left|right)most | (high|low)est)]_point functions were not previously hit
- `operators.rs`:
  - The mapping from function enum to corresponding function pointer was never being verified
- `trapezoid_rasterizer.rs`:
  - No test for panicking on trapezoid creation from non-parallel bases existed