### PR TITLE
Debug utils

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 repository = "https://github.com/CairusOrg/cairus"
 keywords = ["graphics",]
 license = "LGPL-2.1/MPL-2.0"
+build = "build.rs"
 
 [dependencies]
 image = '0.12.2'

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,24 @@
+use std::fs;
+use std::env;
+
+fn main() {
+    if debug_tesselator_flag_on() {
+        let mut cwd = env::current_dir().unwrap();
+        cwd.push("target");
+        cwd.push("debug");
+        cwd.push("images");
+
+        let result = fs::create_dir_all(cwd);
+        match result {
+            Ok(_) => println!("/target/debug/images/ created"),
+            Err(_) => panic!("/target/debug/images/ not created"),
+        }
+    }
+}
+
+fn debug_tesselator_flag_on() -> bool {
+    match env::var("CARGO_FEATURE_DEBUG_TESSELATOR") {
+        Ok(_) => true,
+        Err(_) => false
+    }
+}

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -37,6 +37,7 @@
 
 use std::ops::{Add, Sub};
 use std::f32;
+use types::Pixel;
 
 /// ## Point
 ///
@@ -181,7 +182,7 @@ impl LineSegment {
 
     // Returns a Vector of coordinates indicating which pixels this line should color when
     // rasterized.  The algorithm is a straight-forward DDA.
-    pub fn into_pixel_coordinates(&self) -> Vec<(i32, i32)> {
+    pub fn into_pixels(&self) -> Vec<Pixel> {
         let (x_increment, y_increment) = self.dda_xy_increments();
         let steps = self.dda_steps() as i32;
         let start = self.dda_start_point();
@@ -192,7 +193,7 @@ impl LineSegment {
         for _ in 0..steps {
             x += x_increment;
             y += y_increment;
-            coordinates.push((x as i32, y as i32));
+            coordinates.push(Pixel{x: x as i32, y: y as i32});
         }
         coordinates
     }
@@ -325,6 +326,7 @@ impl PartialEq for Vector {
 #[cfg(test)]
 mod tests {
     use super::{LineSegment, Point, Vector};
+    use types::Pixel;
 
     // Tests that point subtraction is working.
     #[test]
@@ -499,7 +501,7 @@ mod tests {
     }
 
     #[test]
-      fn line_into_pixel_coordinates_slope_lt_one() {
+      fn line_into_pixels_slope_lt_one() {
           // The following coordinates were calculated by hand to be known pixels in the defined
           // line.
           let line = LineSegment::new(0., 0., 20., 5.);
@@ -510,20 +512,20 @@ mod tests {
             (4, 1),
             (5, 1),
             (6, 1)
-          ];
+          ].into_iter().map(|(x, y)| Pixel{x: x, y: y}).collect::<Vec<Pixel>>();
 
-          let pixel_coordinates = line.into_pixel_coordinates();
+          let pixels = line.into_pixels();
           for coordinate in expected {
-              assert!(pixel_coordinates.contains(&coordinate));
+              assert!(pixels.contains(&coordinate));
           }
       }
 
       #[test]
-      fn line_into_pixel_coordinates_slope_gt_one() {
+      fn line_into_pixels_slope_gt_one() {
           // The following coordinates were calculated by hand to be known pixels in the defined
           // line.
           let line = LineSegment::new(0., 0., 5., 20.);
-          let expected = vec![
+          let expected : Vec<Pixel> = vec![
               (0, 1),
               (0, 2),
               (0, 3),
@@ -531,11 +533,11 @@ mod tests {
               (1, 5),
               (1, 6),
               (1, 7)
-          ];
+          ].into_iter().map(|(x, y)| Pixel::new(x, y)).collect();
 
-          let pixel_coordinates = line.into_pixel_coordinates();
+          let pixels = line.into_pixels();
           for coordinate in expected {
-              assert!(pixel_coordinates.contains(&coordinate));
+              assert!(pixels.contains(&coordinate));
           }
       }
 
@@ -543,11 +545,9 @@ mod tests {
       #[test]
       fn line_with_negative_slope() {
           let line = LineSegment { point1: Point { x: 3., y: 2. }, point2: Point { x: 4., y: 0. } };
-          for pixel in line.into_pixel_coordinates() {
-              let x = pixel.0;
-              let y = pixel.1;
-              assert!(y >= 0);
-              assert!(x >= 0);
+          for pixel in line.into_pixels() {
+              assert!(pixel.x >= 0);
+              assert!(pixel.y >= 0);
           }
       }
 
@@ -564,10 +564,10 @@ mod tests {
           let a = Point{x: 0., y: 0.};
           let b = Point{x: 0., y: 10.};
           let line = LineSegment{point1: a, point2: b};
-          let coordinates = line.into_pixel_coordinates();
+          let coordinates = line.into_pixels();
           assert!(coordinates.len() != 0);
           for (idx, coordinate) in coordinates.iter().enumerate() {
-              let expected_coordinate = (0, idx as i32 + 1);
+              let expected_coordinate = Pixel::new(0, idx as i32 + 1);
               assert_eq!(*coordinate, expected_coordinate);
           }
       }
@@ -578,10 +578,10 @@ mod tests {
           let a = Point{x: 0., y: 0.};
           let b = Point{x: 10., y: 0.};
           let line = LineSegment{point1: a, point2: b};
-          let coordinates = line.into_pixel_coordinates();
+          let coordinates = line.into_pixels();
           assert!(coordinates.len() != 0);
           for (idx, coordinate) in coordinates.iter().enumerate() {
-              let expected_coordinate = (idx as i32 + 1, 0);
+              let expected_coordinate = Pixel::new(idx as i32 + 1, 0);
               assert_eq!(*coordinate, expected_coordinate);
           }
       }

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -585,29 +585,4 @@ mod tests {
               assert_eq!(*coordinate, expected_coordinate);
           }
       }
-
-
-      // Tests that an image is output when the debug-tesselator feature flag is set
-      #[cfg(feature = "debug-tesselator")]
-      #[test]
-      fn test_filename() {
-          let mut lines = Vec::new();
-          for x in 0..500 {
-              if x % 25 == 0 {
-                  let upper_y = ((x + 20) as f32).min(500.);
-                  let lower_y = ((x - 20) as f32).max(1.);
-                  if lower_y < 0. {
-                      panic!("Can not be lower than zero");
-                  }
-                  let line = LineSegment::new(x as f32, lower_y, x as f32, upper_y);
-                  lines.push(line);
-              }
-          }
-
-          let line = LineSegment::new(0., 0., 500., 500.);
-          lines.push(line);
-
-          // Test
-          debug_render_lines!(lines, "black");
-      }
 }

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -585,4 +585,29 @@ mod tests {
               assert_eq!(*coordinate, expected_coordinate);
           }
       }
+
+
+      // Tests that an image is output when the debug-tesselator feature flag is set
+      #[cfg(feature = "debug-tesselator")]
+      #[test]
+      fn test_filename() {
+          let mut lines = Vec::new();
+          for x in 0..500 {
+              if x % 25 == 0 {
+                  let upper_y = ((x + 20) as f32).min(500.);
+                  let lower_y = ((x - 20) as f32).max(1.);
+                  if lower_y < 0. {
+                      panic!("Can not be lower than zero");
+                  }
+                  let line = LineSegment::new(x as f32, lower_y, x as f32, upper_y);
+                  lines.push(line);
+              }
+          }
+
+          let line = LineSegment::new(0., 0., 500., 500.);
+          lines.push(line);
+
+          // Test
+          debug_render_lines!(lines, "black");
+      }
 }

--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -37,7 +37,7 @@
 
 use std::ops::{Add, Sub};
 use std::f32;
-use types::Pixel;
+use types::{Pixel, IntoPixels};
 
 /// ## Point
 ///
@@ -179,25 +179,6 @@ impl LineSegment {
         }
     }
 
-
-    // Returns a Vector of coordinates indicating which pixels this line should color when
-    // rasterized.  The algorithm is a straight-forward DDA.
-    pub fn into_pixels(&self) -> Vec<Pixel> {
-        let (x_increment, y_increment) = self.dda_xy_increments();
-        let steps = self.dda_steps() as i32;
-        let start = self.dda_start_point();
-        let mut x = start.x;
-        let mut y = start.y;
-
-        let mut coordinates = Vec::with_capacity(steps as usize);
-        for _ in 0..steps {
-            x += x_increment;
-            y += y_increment;
-            coordinates.push(Pixel{x: x as i32, y: y as i32});
-        }
-        coordinates
-    }
-
     fn dda_xy_increments(&self) -> (f32, f32) {
         let steps = self.dda_steps();
         let (delta_x, delta_y) = self.dda_delta_xy();
@@ -244,6 +225,26 @@ impl PartialEq for LineSegment {
     fn eq(&self, other: &LineSegment) -> bool {
         (self.point1 == other.point1 && self.point2 == other.point2) ||
         (self.point1 == other.point2 && self.point2 == other.point1)
+    }
+}
+
+impl IntoPixels for LineSegment {
+    // Returns a Vector of coordinates indicating which pixels this line should color when
+    // rasterized.  The algorithm is a straight-forward DDA.
+    fn into_pixels(&self) -> Vec<Pixel> {
+        let (x_increment, y_increment) = self.dda_xy_increments();
+        let steps = self.dda_steps() as i32;
+        let start = self.dda_start_point();
+        let mut x = start.x;
+        let mut y = start.y;
+
+        let mut coordinates = Vec::with_capacity(steps as usize);
+        for _ in 0..steps {
+            x += x_increment;
+            y += y_increment;
+            coordinates.push(Pixel{x: x as i32, y: y as i32});
+        }
+        coordinates
     }
 }
 
@@ -326,7 +327,7 @@ impl PartialEq for Vector {
 #[cfg(test)]
 mod tests {
     use super::{LineSegment, Point, Vector};
-    use types::Pixel;
+    use types::{Pixel, IntoPixels};
 
     // Tests that point subtraction is working.
     #[test]

--- a/src/debug_utils.rs
+++ b/src/debug_utils.rs
@@ -141,7 +141,6 @@ mod tests {
         // Cleanup
         fs::remove_file(path).unwrap();
         assert!(passed);
-
     }
 
     // Tests that an image is output when the debug-tesselator feature flag is set

--- a/src/debug_utils.rs
+++ b/src/debug_utils.rs
@@ -33,6 +33,35 @@
  *
  */
 
+//! This module provides some debugging tools.
+
+// ## Renders a Vec of LineSegments to a '.png' file.
+// This will only compile when the '--feature debug-tesselator' flag is passed to Cargo.
+//
+// ## How to Compile:
+//       cargo test --features debug-tesselator
+//  or:
+//       cargo run --features debug-tesselator
+//
+// The following example will render the two LineSegments in red to a 25x25 png file called
+// "debug_lines.png".
+//
+// ## Usage:
+//
+// ```
+//      let lines = vec![
+//          LineSegment::new(0., 0., 20., 20.),
+//          LineSegment::new(20., 0., 0., 20.),
+//      ];
+//
+//      debug_render_lines!(lines, "red", 25, 25, "debug_lines.png");
+//
+// ```
+//
+//
+//  Warning! Make sure your LineSegments are smaller than the width/height you pass the macro,
+//  otherwise it will throw an error.
+//
 // The debug version
 #[cfg(feature = "debug-tesselator")]
 macro_rules! debug_render_lines {
@@ -40,7 +69,6 @@ macro_rules! debug_render_lines {
         use types::Rgba;
         use surfaces::ImageSurface;
         use std::path::Path;
-
 
         let color =
             match $color.as_ref() {
@@ -67,15 +95,17 @@ macro_rules! debug_render_lines {
     }
 }
 
+
 // Non-debug version
+// This is here so that when the '--feature debug-tesselator' flag is not set
+// the compiler will still compile but this macro won't generate any code.
 #[cfg(not(feature = "debug-tesselator"))]
 macro_rules! debug_render_lines {
     ($lines:expr, $color:expr, $width:expr, $height:expr, $pathname:expr) => {}
 }
 
-
 // Unused imports are allowed because as the 'debug-tesselator' flag is turned on and off,
-// certain imports become used and unused. 
+// certain imports become used and unused.
 #[allow(unused_imports)]
 #[macro_use]
 #[cfg(test)]
@@ -130,5 +160,4 @@ mod tests {
 
         assert_eq!(exists, false);
     }
-
 }

--- a/src/debug_utils.rs
+++ b/src/debug_utils.rs
@@ -74,7 +74,7 @@ macro_rules! debug_render_lines {
             use $crate::types::Rgba;
             use surfaces::ImageSurface;
             use debug_utils::get_target_dir;
-            use types::Pixel;
+            use types::{Pixel, IntoPixels};
 
             let color =
                 match $color.as_ref() {

--- a/src/debug_utils.rs
+++ b/src/debug_utils.rs
@@ -74,6 +74,7 @@ macro_rules! debug_render_lines {
             use $crate::types::Rgba;
             use surfaces::ImageSurface;
             use debug_utils::get_target_dir;
+            use types::Pixel;
 
             let color =
                 match $color.as_ref() {
@@ -88,13 +89,13 @@ macro_rules! debug_render_lines {
             let mut max_x = 0 ;
             let mut max_y = 0;
             for line in $lines.iter() {
-                for (x, y) in line.into_pixel_coordinates() {
-                    if x > max_x {
-                        max_x = x;
+                for pixel in line.into_pixels() {
+                    if pixel.x > max_x {
+                        max_x = pixel.x;
                     }
 
-                    if y > max_y {
-                        max_y = y;
+                    if pixel.y > max_y {
+                        max_y = pixel.y;
                     }
                 }
             }
@@ -107,12 +108,16 @@ macro_rules! debug_render_lines {
 
             // Actually color in the pixels
             for line in $lines.iter() {
-                for (x, y) in line.into_pixel_coordinates() {
-                    let mut pixel = surface.get_mut(x as usize, y as usize);
-                    pixel.red = color.red;
-                    pixel.blue = color.blue;
-                    pixel.green = color.green;
-                    pixel.alpha = color.alpha;
+                for pixel in line.into_pixels() {
+                    match surface.get_mut(pixel.x as usize, pixel.y as usize) {
+                        Some(pixel) => {
+                            pixel.red = color.red;
+                            pixel.blue = color.blue;
+                            pixel.green = color.green;
+                            pixel.alpha = color.alpha;
+                        },
+                        None => {},
+                    }
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,10 @@
 /// When we get down to the level of pixels, they are blended together by operations
 /// defined in the operators module.
 #[allow(dead_code)]
+#[macro_use]
+mod debug_utils;
+
+#[allow(dead_code)]
 pub mod operators;
 
 #[allow(dead_code)]
@@ -63,6 +67,3 @@ mod trapezoid_rasterizer;
 
 #[allow(dead_code)]
 mod common_geometry;
-
-#[allow(dead_code)]
-mod debug_utils;

--- a/src/surfaces.rs
+++ b/src/surfaces.rs
@@ -180,7 +180,7 @@ impl ImageSurface {
     }
 
     fn calculate_position(width: usize, x: usize, y: usize) -> usize {
-        y * width + x
+        y.wrapping_mul(width).wrapping_add(x)
     }
 }
 

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -131,19 +131,19 @@ use types::{Pixel, IntoPixels};
 /// TODO: Implement `fn points()` or `fn a()`, `fn b()` , etc...
 /// TODO: Test/verify degenerate Trapezoid (a triangle) is still valid
 pub struct Trapezoid {
-    lines: Vec<LineSegment>
+    pub lines: Vec<LineSegment>
 }
 
 impl Trapezoid {
 
     // Returns a new Trapezoid defined by points.
-    fn from_points(a: Point, b: Point, c: Point, d: Point) -> Trapezoid {
+    pub fn from_points(a: Point, b: Point, c: Point, d: Point) -> Trapezoid {
         let bases = bases_from_points(a, b, c, d);
         Trapezoid::from_bases(bases[0].0, bases[0].1)
     }
 
     // Returns a new Trapezoid from two bases
-    fn from_bases(base1: LineSegment, base2: LineSegment) -> Trapezoid {
+    pub fn from_bases(base1: LineSegment, base2: LineSegment) -> Trapezoid {
         if base1.length() != 0. &&
            base2.length() != 0. &&
            base1.slope() != base2.slope() {
@@ -155,12 +155,12 @@ impl Trapezoid {
         }
     }
 
-    fn lines(&self) -> &Vec<LineSegment> {
+    pub fn lines(&self) -> &Vec<LineSegment> {
         &self.lines
     }
 
     /// Returns true if this Trapezoid contains `point`, otherwise returns false
-    fn contains_point(&self, point: &Point) -> bool {
+    pub fn contains_point(&self, point: &Point) -> bool {
         let mut crossing_count = 0;
         for line in self.lines().iter() {
             if ray_from_point_crosses_line(point, line) {

--- a/src/trapezoid_rasterizer.rs
+++ b/src/trapezoid_rasterizer.rs
@@ -119,7 +119,7 @@ use surfaces::ImageSurface;
 use common_geometry::{Point, LineSegment};
 use std::f32;
 use std::collections::HashMap;
-use types::Pixel;
+use types::{Pixel, IntoPixels};
 
 /// ## Trapezoid
 ///
@@ -171,10 +171,10 @@ impl Trapezoid {
         crossing_count % 2 != 0
     }
 
+}
+
+impl IntoPixels for Trapezoid {
     /// Converts this trapezoid into a Vec of Pixels
-    ///
-    /// The returned pixels don't contain color or alpha information, they are just the coordinates
-    /// for the pixels that this trapezoid covers.
     fn into_pixels(&self) -> Vec<Pixel> {
         let mut outline_pixels = Vec::new();
         for line in self.lines() {
@@ -215,6 +215,7 @@ impl Trapezoid {
         pixels
     }
 }
+
 
 // Defines a collection for holding a Trapezoid's bases.
 //

--- a/src/types.rs
+++ b/src/types.rs
@@ -36,6 +36,8 @@
 //!
 //! Currently the only types here are for representing color.
 
+use common_geometry::Point;
+
 /// Represents color with red, green, blue, and alpha channels.
 #[derive(Debug, Clone, Copy)]
 pub struct Rgba {
@@ -102,6 +104,36 @@ impl PartialEq for Rgba {
     fn eq(&self, other: &Rgba) -> bool {
         self.red == other.red && self.green == other.green &&
         self.blue == other.blue && self.alpha == other.alpha
+    }
+}
+
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Pixel {
+    pub x: i32,
+    pub y: i32,
+}
+
+impl Pixel {
+    /// Returns a Vec of Points whose coordinates are the points to be sampled for anti-aliasing.
+    pub fn sample_points(&self) -> Vec<Point> {
+        let mut points = Vec::new();
+        let x_increment = 1. / 16.;
+        let y_increment = 1. / 14.;
+        for subgrid_x in 0..17 {
+            let x = self.x as f32 + (subgrid_x as f32 * x_increment);
+            for subgrid_y in 0..15 {
+                let y =  self.y as f32 + (subgrid_y as f32 * y_increment);
+                let point = Point{x: x, y: y};
+                points.push(point);
+            }
+        }
+
+        points
+    }
+
+    pub fn new(x: i32, y: i32) -> Pixel {
+        Pixel {x: x, y: y}
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -137,6 +137,10 @@ impl Pixel {
     }
 }
 
+pub trait IntoPixels {
+    fn into_pixels(&self) -> Vec<Pixel>;
+}
+
 #[cfg(test)]
 mod tests {
     use super::Rgba;


### PR DESCRIPTION
- IntoPixels Trait, for anything that can be converted to pixels
- Impl IntoPixels for Trapezoid and LineSegment
- Added the debug_render! macro for rendering any Vec<T: IntoPixels> to a .png
- Fixed the vertical line segment rasterization bug
- Made surface::get_mut() return an Option<&mut Rgba> instead of just an &mut Rgba
- Changed all `fn into_pixel_coordinates` to `fn into_pixels` impl of `IntoPixels` trait