### PR TITLE
Bug Fix: needed to make the variables in common_geometry::Edge public…

### DIFF
--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -232,10 +232,10 @@ impl PartialEq for LineSegment {
 
 #[derive(Copy)]
 pub struct Edge {
-    line: LineSegment,
-    top: f32,
-    bottom: f32,
-    direction: i32,
+    pub line: LineSegment,
+    pub top: f32,
+    pub bottom: f32,
+    pub direction: i32,
 }
 
 impl Clone for Edge {


### PR DESCRIPTION
Changed the variables inside of the Edge struct to public so they are accessible. 