### PR TITLE
Debug renderer and rasterizer hack for better speed for demo

### DIFF
--- a/src/common_geometry.rs
+++ b/src/common_geometry.rs
@@ -242,7 +242,7 @@ impl IntoPixels for LineSegment {
         for _ in 0..steps {
             x += x_increment;
             y += y_increment;
-            coordinates.push(Pixel{x: x as i32, y: y as i32});
+            coordinates.push(Pixel{x: x as i32, y: y as i32, is_edge: true});
         }
         coordinates
     }
@@ -513,7 +513,7 @@ mod tests {
             (4, 1),
             (5, 1),
             (6, 1)
-          ].into_iter().map(|(x, y)| Pixel{x: x, y: y}).collect::<Vec<Pixel>>();
+          ].into_iter().map(|(x, y)| Pixel{x: x, y: y, is_edge: true}).collect::<Vec<Pixel>>();
 
           let pixels = line.into_pixels();
           for coordinate in expected {

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -148,7 +148,7 @@ pub fn fetch_operator(op: &Operator) -> fn(&Rgba, &mut Rgba) {
 /// Over is Cairus's default operator.  If the source is semi-transparent, the over operation will
 /// blend the source and the destination.  If the source is opaque, it will cover the destination
 /// without blending.  Assumes pre-multiplied alpha.
-fn operator_over(source: &Rgba, destination: &mut Rgba) {
+pub fn operator_over(source: &Rgba, destination: &mut Rgba) {
     destination.alpha = source.alpha + destination.alpha * (1. - source.alpha);
     destination.red = source.red + destination.red * (1. - source.alpha);
     destination.green = source.green + destination.green * (1. - source.alpha);
@@ -157,7 +157,7 @@ fn operator_over(source: &Rgba, destination: &mut Rgba) {
 
 /// Source operator. The destination object is overwritten with the source object. Result is
 /// equal to the source in both color values and alpha.
-fn operator_source(source: &Rgba, destination: &mut Rgba) {
+pub fn operator_source(source: &Rgba, destination: &mut Rgba) {
     destination.alpha = source.alpha;
     destination.red = source.red;
     destination.green = source.green;
@@ -171,7 +171,7 @@ fn operator_source(source: &Rgba, destination: &mut Rgba) {
 ///This operator is unbounded.
 ///This function currently assumes post-multiplied alpha values, the alpha value
 ///must be factored out
-fn operator_in(source: &Rgba, destination: &mut Rgba) {
+pub fn operator_in(source: &Rgba, destination: &mut Rgba) {
     destination.alpha = source.alpha * destination.alpha;
     destination.red = source.red;
     destination.green = source.green;

--- a/src/surfaces.rs
+++ b/src/surfaces.rs
@@ -179,6 +179,14 @@ impl ImageSurface {
         self.base.get_mut(position)
     }
 
+    pub fn get_with_index(&self, idx: usize) -> Option<&Rgba> {
+        self.base.get(idx)
+    }
+
+    pub fn get_mut_with_index(&mut self, idx: usize) -> Option<&mut Rgba> {
+        self.base.get_mut(idx)
+    }
+
     fn calculate_position(width: usize, x: usize, y: usize) -> usize {
         y.wrapping_mul(width).wrapping_add(x)
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -112,6 +112,7 @@ impl PartialEq for Rgba {
 pub struct Pixel {
     pub x: i32,
     pub y: i32,
+    pub is_edge: bool,
 }
 
 impl Pixel {
@@ -133,7 +134,11 @@ impl Pixel {
     }
 
     pub fn new(x: i32, y: i32) -> Pixel {
-        Pixel {x: x, y: y}
+        Pixel {x: x, y: y, is_edge: true}
+    }
+
+    pub fn is_edge(&self) -> bool {
+        self.is_edge
     }
 }
 


### PR DESCRIPTION
This does two things.

It adds a `debug_render_traps!` macro for anti-aliasing trapezoids.  Note that the bulk of this code is copy and pasted and is total garbage, yet functional.  It is there in the case we don't finish but we need to show something (like the deCastleJau/BO/Raster outputs).

The other addition is that I hacked to other some other crap to make the rasterizer go from being mind boggling slow to only very, very slow.

There needs to be a number of refactorings:

1. Remove extra loops
2. Use math instead of iterations to determine min/max (x, y) values by using the function of the lines.
3. Optimize for Horizontal line pixels by only sampling one pixel.
4. Change any return vector into an iterator